### PR TITLE
:bug: Fix typesetting  in the introduction of "Hello World"

### DIFF
--- a/source/topic1.rst
+++ b/source/topic1.rst
@@ -190,7 +190,7 @@ Can I write a program now?
 ==========================
 
 * If you have looked at :doc:`get set up for CSCI 161 </gettingset>`, then yes
-* Go to Google Colab and make your ``Hello, world!" program 
+* Go to Google Colab and make your "Hello, world!" program 
     * `"Hello, world!" <http://en.wikipedia.org/wiki/Hello_world_program>`_ is traditionally the first program one writes in a new language.
     
 	``print("Hello, world!")``


### PR DESCRIPTION
### What
Fix the typesetting of hello world. It was ` ``Hello, world!"`  instead of `"Hello, world!"`. 

### Why
It broke the typesetting and made a weird link back to the page. 

### Additional Notes
I've been using a lot of LaTeX lately. 
