### PR TITLE
:new: :mortar_board: Add link to twitch channel 

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -22,6 +22,7 @@ Professors
 * Dr. James Hughes (Section 11)
 * jhughes at stfx.ca
 * `@Modsurski <https://twitter.com/Modsurski>`_
+* `Twitch "Office Hours" <https://www.twitch.tv/conlabx>`_
 * **GO HERE** **GO HERE** **GO HERE** **GO HERE** **GO HERE** `YouTube <https://www.youtube.com/channel/UCIruexBZJaawh_9WF_vjTPg>`_ **GO HERE** **GO HERE** **GO HERE** **GO HERE** **GO HERE**
 
 * Dr. Jean-Alexis Delamer (Section 12)

--- a/source/topic1.rst
+++ b/source/topic1.rst
@@ -197,7 +197,7 @@ Can I write a program now?
 
 * You're now officially a computer programmer!   
 
-. image:: ../img/HelloWorldColab.png
+.. image:: ../img/HelloWorldColab.png
    
    
 Videos


### PR DESCRIPTION
### What
Add a link to the twitch channel for "Office Hours". 

### Why
So they can find it easy. 

### Additional Notes
This will now be closer to the index page for CS 102. 
