### PR TITLE
:mortar_board: add GitHub link

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -16,6 +16,9 @@ An introduction to computers, algorithms, and programming. No previous knowledge
 
 This course is devoted to learning proper problem solving techniques and basic programming skills. Topics include problem analysis, algorithm development, data representation, control structures, lists, functions, and file manipulation.
 
+`The content used to generate the course can be found on GitHub <https://github.com/jameshughes89/cs101>`_ 
+
+
 Professors
 ==========
 


### PR DESCRIPTION
### What
Add a link to the github page for the course. 

### Why
Students can easily access it from the page itself. Hopefully it will make it easier to participate in the content creating. 

### Where
Right near the top, under the description. 