### PR TITLE
:lipstick::bug: Topic3 (kinda) Change the math extension

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -25,7 +25,7 @@ import sys, os
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.imgmath']
+extensions = ['sphinx.ext.mathjax']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
### Related Issues or PRs
Fixes the math rendering issue noted in #50 

### What
Change the math `sphinx.ext.imgmath` -> `sphinx.ext.mathjax`, like how it is for cs102. 

### Why
Wasn't working correctly because I think something with LaTeX

### How
Copy from cs102's conf.py file

### Testing
~I _will_ verify after action~ 
Yep --- works. 