### PR TITLE
:mortar_board: Lab2 Add link to course content on `return`

### DIFF
--- a/source/lab2.rst
+++ b/source/lab2.rst
@@ -32,7 +32,7 @@ Before Kattis
 4. Write a **function** called ``add_three_nums_print`` that takes three integers as parameters, adds them together, and then prints out the result. Call the function to verify its correctness. You **MUST** do this with a function.
 
 
-5. Write a **function** called ``add_two_nums_return`` that takes two integers as parameters, adds them together, and then *returns* the result. Effectively this will be identical to ``add_two_nums_print``, but replace the ``print`` inside the function (in addition to the one in the name of the function) with ``return``. Run the following code to verify its correctness. :doc:`What's return? </topic3#function-values>`
+5. Write a **function** called ``add_two_nums_return`` that takes two integers as parameters, adds them together, and then *returns* the result. Effectively this will be identical to ``add_two_nums_print``, but replace the ``print`` inside the function (in addition to the one in the name of the function) with ``return``. Run the following code to verify its correctness. `What's return? <http://modsurski.com/csci161/topic3.html#function-values>`_
 
     .. code-block:: python
    

--- a/source/lab2.rst
+++ b/source/lab2.rst
@@ -32,7 +32,7 @@ Before Kattis
 4. Write a **function** called ``add_three_nums_print`` that takes three integers as parameters, adds them together, and then prints out the result. Call the function to verify its correctness. You **MUST** do this with a function.
 
 
-5. Write a **function** called ``add_two_nums_return`` that takes two integers as parameters, adds them together, and then *returns* the result. Effectively this will be identical to ``add_two_nums_print``, but replace the ``print`` inside the function (in addition to the one in the name of the function) with ``return``. Run the following code to verify its correctness. :doc:`What return? </topic3#function-values>`
+5. Write a **function** called ``add_two_nums_return`` that takes two integers as parameters, adds them together, and then *returns* the result. Effectively this will be identical to ``add_two_nums_print``, but replace the ``print`` inside the function (in addition to the one in the name of the function) with ``return``. Run the following code to verify its correctness. :doc:`What's return? </topic3#function-values>`
 
     .. code-block:: python
    

--- a/source/lab2.rst
+++ b/source/lab2.rst
@@ -32,7 +32,7 @@ Before Kattis
 4. Write a **function** called ``add_three_nums_print`` that takes three integers as parameters, adds them together, and then prints out the result. Call the function to verify its correctness. You **MUST** do this with a function.
 
 
-5. Write a **function** called ``add_two_nums_return`` that takes two integers as parameters, adds them together, and then *returns* the result. Effectively this will be identical to ``add_two_nums_print``, but replace the ``print`` inside the function (in addition to the one in the name of the function) with ``return``. Run the following code to verify its correctness. 
+5. Write a **function** called ``add_two_nums_return`` that takes two integers as parameters, adds them together, and then *returns* the result. Effectively this will be identical to ``add_two_nums_print``, but replace the ``print`` inside the function (in addition to the one in the name of the function) with ``return``. Run the following code to verify its correctness. :doc:`What return? </topic3#function-values>`
 
     .. code-block:: python
    

--- a/source/lab2.rst
+++ b/source/lab2.rst
@@ -4,12 +4,15 @@ Lab #2
 
 Remember, the point of the lab is **not** to complete the tasks. The point of the labs is to understand why the code you have written does what it does. Do not rush through the steps. Take your time and understand everything we are doing. The understanding is important, **not** just knocking off the tasks. 
 
+
+
 Before Kattis
 =============
 
 1. If you missed the first lab, go complete steps 10 -- 16 in lab 1. 
 
 **NOTE:**  :doc:`If you forget how to do the function stuff, go back to the class notes. </topic3>`
+
 
 2. Write a **function** called ``add_five_print`` that takes one integer as a parameter, adds five to it, and then prints out the result. Call the function to verify its correctness. You **MUST** do this with a function. Below I have given you the code you need to start writing your function. 
 
@@ -18,13 +21,16 @@ Before Kattis
         def add_five_print(aNum):
             # stuff goes here
 
+
 3. Write a **function** called ``add_two_nums_print`` that takes two integers as parameters, adds them together, and then prints out the result. Call the function to verify its correctness. You **MUST** do this with a function. Below is the code you can use to call the function and test it after you have written/defined the function. 
 
     .. code-block:: python
     
         add_two_nums_print(4, 5)
 
+
 4. Write a **function** called ``add_three_nums_print`` that takes three integers as parameters, adds them together, and then prints out the result. Call the function to verify its correctness. You **MUST** do this with a function.
+
 
 5. Write a **function** called ``add_two_nums_return`` that takes two integers as parameters, adds them together, and then *returns* the result. Effectively this will be identical to ``add_two_nums_print``, but replace the ``print`` inside the function (in addition to the one in the name of the function) with ``return``. Run the following code to verify its correctness. 
 
@@ -33,12 +39,14 @@ Before Kattis
         a = add_two_nums_return(4, 5)
         print(a)
 
+
 6. Call the function ``add_two_nums_print`` you wrote in step 3 with the below code. What do you notice? See if you can hack around a little to figure out the difference between ``print`` and ``return`` (there's a HUGE difference). Take your time on this one. 
 
     .. code-block:: python
         
         b = add_two_nums_print(4, 5)
         print(b)
+       
         
 7. Write a function called ``this_is_tough`` that takes four integers as parameters. This function will ultimately add up the four integers and *return* the result. **HOWEVER**, inside this function you are **not** allowed to use the addition operator (or any arithmetic trick to do addition, like, ``5 - (-1*6)``), you are required to use the ``add_two_nums_return`` written above. You may **not** use ``print`` inside this function (use ``return``). A big hint: You will likely want to call the ``add_two_nums_return`` function a total of 3 times. Test that it works with the following code. 
   
@@ -46,6 +54,8 @@ Before Kattis
         
         c = this_is_tough(3, 4, 6, 7)
         print(c)
+
+
 
 Kattis Problems
 ===============


### PR DESCRIPTION
### What
Add a link the explination of `return` in the course content. Also, I added whitespace too. 

### Why
It will ideally help them with independent learning (at least, they will hopefully click the link) 

### How
Trying with `:doc:`, but I don't actually know if I can do it the way I did. 

### Testing
~I'll check the build to see if it works.~
It didn't work, I changed it to just a link and it works. 

### Additional Notes
If it doesn't work with `:doc:`, it will with this: `What return? <http://modsurski.com/csci161/topic3.html#function-values>`_