### PR TITLE
:mortar_board::lipstick: Topic3 Clean up `do_stuff` example

### DIFF
--- a/source/topic3.rst
+++ b/source/topic3.rst
@@ -252,7 +252,8 @@ Execution Flow
 	
     x = 2
     y = 3
-    print(do_stuff(x, y))
+    z = do_stuff(x, y)
+    print(z)
     print('where am I?')
 
 * So what happens is:

--- a/source/topic3.rst
+++ b/source/topic3.rst
@@ -254,7 +254,7 @@ Execution Flow
     y = 3
     z = do_stuff(x, y)
     print(z)
-    print('where am I?')
+    print("where am I?")
 
 * So what happens is:
     * Program starts at the top, and computer sees that a function is being *declared* (not called yet)

--- a/source/topic3.rst
+++ b/source/topic3.rst
@@ -244,15 +244,15 @@ Execution Flow
     * Later, we'll learn how to jump around
 * What happens when a function gets called? Let's trace through this program::
 
-    def do_stuff(a,b):
-        c = b*2
-        d = (a+4)*2
+    def do_stuff(a, b):
+        c = b * 2
+        d = (a+4) * 2
         c = d + c
         return c
 	
     x = 2
     y = 3
-    print(do_stuff(x,y))
+    print(do_stuff(x, y))
     print('where am I?')
 
 * So what happens is:


### PR DESCRIPTION
### What
1. Add spaces between params
2. add spaces to match operator conventions (apparently in Python they recommend no space for things of higher priority --- I never knew this)
3. Changed single quote to double quote. Not needed, but idk, will match Java for next semester better. 
4. Assign the function's returned value to a variable to help emphasize that it's being evaluated to a value

### Why
Mostly for conventions. 