### PR TITLE
:lipstick: Clean up prof part of index page

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -22,14 +22,14 @@ This course is devoted to learning proper problem solving techniques and basic p
 Professors
 ==========
 
-* Dr. James Hughes (Section 11)
+* **Dr. James Hughes (Section 11)**
 * jhughes at stfx.ca
 * `@Modsurski <https://twitter.com/Modsurski>`_
 * `Twitch "Office Hours" <https://www.twitch.tv/conlabx>`_
 * `YouTube <https://www.youtube.com/channel/UCIruexBZJaawh_9WF_vjTPg>`_
 
 
-* Dr. Jean-Alexis Delamer (Section 12)
+* **Dr. Jean-Alexis Delamer (Section 12)**
 * jdelamer at stfx.ca
 
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -22,14 +22,18 @@ This course is devoted to learning proper problem solving techniques and basic p
 Professors
 ==========
 
-* **Dr. James Hughes (Section 11)**
+Dr. James Hughes (Section 11)
+-----------------------------
+
 * jhughes at stfx.ca
 * `@Modsurski <https://twitter.com/Modsurski>`_
 * `Twitch "Office Hours" <https://www.twitch.tv/conlabx>`_
 * `YouTube <https://www.youtube.com/channel/UCIruexBZJaawh_9WF_vjTPg>`_
 
 
-* **Dr. Jean-Alexis Delamer (Section 12)**
+Dr. Jean-Alexis Delamer (Section 12)
+------------------------------------
+
 * jdelamer at stfx.ca
 
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -26,7 +26,8 @@ Professors
 * jhughes at stfx.ca
 * `@Modsurski <https://twitter.com/Modsurski>`_
 * `Twitch "Office Hours" <https://www.twitch.tv/conlabx>`_
-* **GO HERE** **GO HERE** **GO HERE** **GO HERE** **GO HERE** `YouTube <https://www.youtube.com/channel/UCIruexBZJaawh_9WF_vjTPg>`_ **GO HERE** **GO HERE** **GO HERE** **GO HERE** **GO HERE**
+* `YouTube <https://www.youtube.com/channel/UCIruexBZJaawh_9WF_vjTPg>`_
+
 
 * Dr. Jean-Alexis Delamer (Section 12)
 * jdelamer at stfx.ca


### PR DESCRIPTION
### What
1. Remove the excess **'GO HERE'** for YouTube.
~2. Bold face the names for more of a pop~
2. Make prof names subsection titles. 

### Why
Looked like a mess, and Jean-Alexis' name felt lost in the points. 