### PR TITLE
:lipstick::telescope: Change names to bold from subsections

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -22,8 +22,7 @@ This course is devoted to learning proper problem solving techniques and basic p
 Professors
 ==========
 
-Dr. James Hughes (Section 11)
------------------------------
+**Dr. James Hughes (Section 11)**
 
 * jhughes at stfx.ca
 * `@Modsurski <https://twitter.com/Modsurski>`_
@@ -31,8 +30,8 @@ Dr. James Hughes (Section 11)
 * `YouTube <https://www.youtube.com/channel/UCIruexBZJaawh_9WF_vjTPg>`_
 
 
-Dr. Jean-Alexis Delamer (Section 12)
-------------------------------------
+**Dr. Jean-Alexis Delamer (Section 12)**
+
 
 * jdelamer at stfx.ca
 


### PR DESCRIPTION
### Related Issues or PRs
Quick change to #58 

### What
Change the prof names from being subsections to just bold faced. 

### Why
1. The subsection strategy ended up making the font too big
2. The bold face was used everywhere else on the page. 