### PR TITLE
:bomb: Labs Remove 'online section' instructions

### DIFF
--- a/source/lab1.rst
+++ b/source/lab1.rst
@@ -134,7 +134,3 @@ Grab a scrap piece of paper to start scratching your ideas down on paper.
 
 
 **ENSURE WE HAVE RECORDED YOUR COMPLETION. FAILURE TO DO SO WILL RESULT IN A GRADE OF 0!**
-
-.. warning::
-   
-    If you are in the online section, you **must** submit the .py (python scripts), not the .ipynb (notebook files). To get the python scripts from Colab, simply select *File* and in te dropdown menue, hit *Download .py*. 

--- a/source/lab10.rst
+++ b/source/lab10.rst
@@ -193,7 +193,3 @@ At this point, many of the not-so-difficult problems are totally doable by you n
 If you have somehow finished everything so far, go check out `LeetCode <https://leetcode.com/problemset/all/>`_. Sort the problems by *Acceptance* (click the table header) and start seeing if you can solve some of these problems. 
 
 **ENSURE WE HAVE RECORDED YOUR COMPLETION. FAILURE TO DO SO WILL RESULT IN A GRADE OF 0!**
-
-.. warning::
-   
-    If you are in the online section, you **must** submit the .py (python scripts), not the .ipynb (notebook files). To get the python scripts from Colab, simply select *File* and in te dropdown menue, hit *Download .py*. 

--- a/source/lab11.rst
+++ b/source/lab11.rst
@@ -113,7 +113,3 @@ Remember, the Kattis problems are great for practice, and practice is the only w
 At this point, many of the not-so-difficult problems are totally doable by you now. If you're looking for more problems, or want more practice for tests, etc. sort the Kattis problems by difficulty and have fun. 
 
 **ENSURE WE HAVE RECORDED YOUR COMPLETION. FAILURE TO DO SO WILL RESULT IN A GRADE OF 0!**
-
-.. warning::
-   
-    If you are in the online section, you **must** submit the .py (python scripts), not the .ipynb (notebook files). To get the python scripts from Colab, simply select *File* and in te dropdown menue, hit *Download .py*. 

--- a/source/lab12.rst
+++ b/source/lab12.rst
@@ -60,7 +60,3 @@ Part 2
 Go work through the course content for :doc:`Topic 18 </topic18>` and :doc:`Topic 19 </topic19>`.
 
 **ENSURE WE HAVE RECORDED YOUR COMPLETION. FAILURE TO DO SO WILL RESULT IN A GRADE OF 0!**
-
-.. warning::
-   
-    If you are in the online section, you **must** submit the .py (python scripts), not the .ipynb (notebook files). To get the python scripts from Colab, simply select *File* and in te dropdown menue, hit *Download .py*. 

--- a/source/lab2.rst
+++ b/source/lab2.rst
@@ -96,7 +96,3 @@ Skip any of the following problems if you did them already.
 14. `Go to Kattis and sort the problems by difficulty <https://open.kattis.com/problems?order=problem_difficulty>`_. Read them, understand the problem, then see if you can figure any out. Most you can't yet, but still see what you can do and what you CAN'T.  Try to figure out *why* you can't.  
 
 **ENSURE WE HAVE RECORDED YOUR COMPLETION. FAILURE TO DO SO WILL RESULT IN A GRADE OF 0!**
-
-.. warning::
-   
-    If you are in the online section, you **must** submit the .py (python scripts), not the .ipynb (notebook files). To get the python scripts from Colab, simply select *File* and in te dropdown menue, hit *Download .py*. 

--- a/source/lab3.rst
+++ b/source/lab3.rst
@@ -50,7 +50,3 @@ Remember, here is the *magic* code we needed last week::
 
 
 **ENSURE WE HAVE RECORDED YOUR COMPLETION. FAILURE TO DO SO WILL RESULT IN A GRADE OF 0!**
-
-.. warning::
-   
-    If you are in the online section, you **must** submit the .py (python scripts), not the .ipynb (notebook files). To get the python scripts from Colab, simply select *File* and in te dropdown menue, hit *Download .py*. 

--- a/source/lab4.rst
+++ b/source/lab4.rst
@@ -49,7 +49,3 @@ If you are done everything, feel free to work on the assignment. Just note that 
 
 
 **ENSURE WE HAVE RECORDED YOUR COMPLETION. FAILURE TO DO SO WILL RESULT IN A GRADE OF 0!**
-
-.. warning::
-   
-    If you are in the online section, you **must** submit the .py (python scripts), not the .ipynb (notebook files). To get the python scripts from Colab, simply select *File* and in te dropdown menue, hit *Download .py*. 

--- a/source/lab5.rst
+++ b/source/lab5.rst
@@ -42,7 +42,3 @@ Grab a scrap piece of paper to start scratching your ideas down on paper. The pr
 
 
 **ENSURE WE HAVE RECORDED YOUR COMPLETION. FAILURE TO DO SO WILL RESULT IN A GRADE OF 0!**
-
-.. warning::
-   
-    If you are in the online section, you **must** submit the .py (python scripts), not the .ipynb (notebook files). To get the python scripts from Colab, simply select *File* and in te dropdown menue, hit *Download .py*. 

--- a/source/lab6.rst
+++ b/source/lab6.rst
@@ -47,7 +47,3 @@ Grab a scrap piece of paper to start scratching your ideas down on paper. The pr
 If you finish this lab, go check out `LeetCode <https://leetcode.com/problemset/all/>`_. Sort the problems by *Acceptance* (click the table header) and start seeing if you can solve some of these problems. 
 
 **ENSURE WE HAVE RECORDED YOUR COMPLETION. FAILURE TO DO SO WILL RESULT IN A GRADE OF 0!**
-
-.. warning::
-   
-    If you are in the online section, you **must** submit the .py (python scripts), not the .ipynb (notebook files). To get the python scripts from Colab, simply select *File* and in te dropdown menue, hit *Download .py*. 

--- a/source/lab7.rst
+++ b/source/lab7.rst
@@ -150,7 +150,3 @@ If you finish the lab, go back and work on incomplete problems from previous lab
 If you have somehow finished everything so far, go check out `LeetCode <https://leetcode.com/problemset/all/>`_. Sort the problems by *Acceptance* (click the table header) and start seeing if you can solve some of these problems. 
 
 **ENSURE WE HAVE RECORDED YOUR COMPLETION. FAILURE TO DO SO WILL RESULT IN A GRADE OF 0!**
-
-.. warning::
-   
-    If you are in the online section, you **must** submit the .py (python scripts), not the .ipynb (notebook files). To get the python scripts from Colab, simply select *File* and in te dropdown menue, hit *Download .py*. 

--- a/source/lab8.rst
+++ b/source/lab8.rst
@@ -93,7 +93,3 @@ LeetCode Problems
 If you have somehow finished everything so far, go check out `LeetCode <https://leetcode.com/problemset/all/>`_. Sort the problems by *Acceptance* (click the table header) and start seeing if you can solve some of these problems. 
 
 **ENSURE WE HAVE RECORDED YOUR COMPLETION. FAILURE TO DO SO WILL RESULT IN A GRADE OF 0!**
-
-.. warning::
-   
-    If you are in the online section, you **must** submit the .py (python scripts), not the .ipynb (notebook files). To get the python scripts from Colab, simply select *File* and in te dropdown menue, hit *Download .py*. 

--- a/source/lab9.rst
+++ b/source/lab9.rst
@@ -330,7 +330,3 @@ LeetCode Problems
 If you have somehow finished everything so far, go check out `LeetCode <https://leetcode.com/problemset/all/>`_. Sort the problems by *Acceptance* (click the table header) and start seeing if you can solve some of these problems. 
 
 **ENSURE WE HAVE RECORDED YOUR COMPLETION. FAILURE TO DO SO WILL RESULT IN A GRADE OF 0!**
-
-.. warning::
-   
-    If you are in the online section, you **must** submit the .py (python scripts), not the .ipynb (notebook files). To get the python scripts from Colab, simply select *File* and in te dropdown menue, hit *Download .py*. 


### PR DESCRIPTION
### What
Remove the details at the end of each lab explaining that the online section must submit their lab via Moodle. 

### Why
There is no online section this year, and these instructions just confuse the students. 

### Where
End of all lab files. It was a WARNING.

### Additional Notes
I was gonna' just comment it out just in case it came back in the future, but (a) I don't think online sections will be back for a while, (b) it's easy to just add the warning back in, and (c) I was too lazy if commenting out the warning would actually work since  the `..` for comments is similar to `.. warning::` for warning, so, idk. Easier to just delete. 
