### PR TITLE
:new: Add tutorial nights to index page

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -128,7 +128,7 @@ MSCS Tutorial Nights
 
 The Math, Stats, and CS Society now has a time and location for our free tutorial sessions. 
 
-* TBD, TBD
+* Mondays, 17:00 -- 19:00, MULH 4024
 
 
 Cool Things


### PR DESCRIPTION
### What
Add the day, time, and place for the MSCS tutorial nights. 

### Why
Students can go there for peer help. 

### Additional Notes
Defo should have done this earlier. 
