### PR TITLE
:bomb: Remove comment about hating young people in car rental eg

### DIFF
--- a/source/lab4.rst
+++ b/source/lab4.rst
@@ -28,7 +28,7 @@ A car rental place needs our help. They want a simple program to calculate how m
 * If the classification is **D**
    * Base charge of $50.00/day
    * Plus $0.30 for every km driven above the 100km/day average allowance. 
-* All renters under the age of 25 are charged an additional $10.00/day because they hate young people
+* All renters under the age of 25 are charged an additional $10.00/day 
 * Print out the final total cost
 
 Kattis Problems

--- a/source/topic5b.rst
+++ b/source/topic5b.rst
@@ -36,7 +36,7 @@ A car rental place needs our help. They want a simple program to calculate how m
     * Base charge of $50.00/day
     * Plus $0.30 for every km driven above the 100km/day average allowance 
     
-* All renters under the age of 25 are charged an additional $10.00/day because they hate young people
+* All renters under the age of 25 are charged an additional $10.00/day
 * Print out the final total cost
 
    


### PR DESCRIPTION
### What
Remove "... because they hate young people" from the car rental example. 

### Why
Feels unnecessary. 

### Additional Notes
I was thinking of changing it to something to insult boomers, but decided against it. Something like "boomers can't be ageist I guess".
