### PR TITLE
:bug: Assignment3 Fix link to aliasing

### DIFF
--- a/source/asn3.rst
+++ b/source/asn3.rst
@@ -14,12 +14,11 @@ Assignment #3: I'm only taking CS to make sick video games
    * 2D lists
    * Generalizing rules 
 
+
 .. warning::
 
-    `Remember, List vs. Pointer to a List! <http://modsurski.com/csci161/topic8.html#aliasing>`_
+    Remember, List vs. Pointer to a List! :ref:`_label-topic8-aliasing`.
     
-    
-       
 
 .. image:: ../img/a3_videoGame.jpg
 

--- a/source/topic8.rst
+++ b/source/topic8.rst
@@ -143,8 +143,13 @@ Mutability
     >>> a
     [5, 7, 10]
 
+
+.. _label-topic8-aliasing:
+
 Aliasing 
 ========
+
+
 
 * Pay attention here, because this is a *major* source of confusion for new programmers.
     * It's not actually that weird, but it does trip people up


### PR DESCRIPTION
### What
Correct the link to aliasing in topic8. 

### Why
It was linking to the old location/website. 

### Where
At the beginning, where I give them a hint (that no one will read) about refs and values and whatnot. 

### How
Replace the link with the correct one (http://modsurski.com/csci161/topic8.html#aliasing)

### Additional Notes
I wish I could link with the `:doc:`, but I can't use the `#` to specify a spot with that. :shrug: 
