### PR TITLE
:lipstick: Rename params and add space

### DIFF
--- a/source/lab6.rst
+++ b/source/lab6.rst
@@ -9,20 +9,20 @@ We're going to do a bunch of linear searchers to start.
 
 **1**
 
-Write a function ``char_is_in_while(char,string)`` that returns ``True`` if the character char appears in the string ``string``, otherwise return ``False``. This function **must** use a *while* loop. 
+Write a function ``char_is_in_while(character, phrase)`` that returns ``True`` if the letter ``character`` appears in the string ``phrase``, otherwise return ``False``. This function **must** use a *while* loop. 
 
 **2**
 
-Write a function ``char_is_in_for(char,string)`` that returns ``True`` if the character char appears in the string ``string``, otherwise return ``False``. This function **must** use a *for* loop. 
+Write a function ``char_is_in_for(char, phrase)`` that returns ``True`` if the letter ``character``appears in the string ``phrase``, otherwise return ``False``. This function **must** use a *for* loop. 
 
 **3**
 
-Write a function ``where_is_while(char,string)`` that returns the index of the first occurrence of ``char`` in ``string``. This function **must** use a *while* loop. 
+Write a function ``where_is_while(char, phrase)`` that returns the index of the first occurrence of ``character`` in ``phrase``. This function **must** use a *while* loop. 
 
 
 **4**
 
-Write a function ``where_is_for(char,string)`` that returns the index of the first occurrence of ``char`` in ``string``. This function **must** use a *for* loop.
+Write a function ``where_is_for(char, phrase)`` that returns the index of the first occurrence of ``character`` in ``phrase``. This function **must** use a *for* loop.
 
 
 Kattis Problems


### PR DESCRIPTION
### What
- Add a space between the parameters.
- Rename `char` -> `character` and `string` to `phrase` params for the functions.

### Why
- Spacing for consistency. 
- Renaming the params since `char` and `string` are keywords in other languages, so this just makes things more different. 

### Where
Lab 6, questions 1 -- 4. 

### Additional Notes
`char` and `string` are fine in python, but this helps make things more distinct. Further, sometimes new students get mixed up with the variable/param names and thinking that, because it's a string, it **has** to be called string, which is not correct. 
