### PR TITLE
:bug: Assignment3 Fix reference to aliasing

### DIFF
--- a/source/asn3.rst
+++ b/source/asn3.rst
@@ -17,7 +17,7 @@ Assignment #3: I'm only taking CS to make sick video games
 
 .. warning::
 
-    Remember, List vs. Pointer to a List! :ref:`label-topic8-aliasing`.
+    Remember, List vs. Pointer to a List! Review the discussion on :ref:`label-topic8-aliasing`.
     
 
 .. image:: ../img/a3_videoGame.jpg


### PR DESCRIPTION
### Related Issues or PRs
Closes #86 

### What
Remove the underscore at the beginning of the reference to aliasing. 

### Why
According to documentation, although an underscore is included at the start when _defining_ a reference, it should not be there when using the reference. 

### Where
Warning at the top of A3. 

### How
Remove the `_`

### Testing
~I'll check the artifact.~ 
It worked, but I need to add more words to make it sound/look right. 