### PR TITLE
:lipstick: Asn2 Remove `numpy`, say `enumerate`, mention `choice`

### DIFF
--- a/source/asn2.rst
+++ b/source/asn2.rst
@@ -143,18 +143,18 @@ Write the following functions:
 3. ``sim_step(cities, p_spread, p_cure)``. This is the most important function in the assignment. This function will execute a single *time step* of your simulation. Depending on how fast you want to think of your zombies spreading, that time step could be a day, an hour, a week, whatever. When modelling a real zombie outbreak, you'd determine the size of your time step from the empirical data. Here is some English-language "pseudocode" for function. You'll have to turn it into Python::
    
     for each city in cities (enumerate?):
-        if the city is infected and random.rand() < p_spread:
-            choose a victim city (at random -- hint: random.randint or maybe random.choice) from the list of this city's neighbours
+        if the city is infected and random.random() < p_spread:
+            choose a victim city (at random -- hint: random.randint, random.randrange, or maybe random.choice) from the list of this city's neighbours
             infect the victim city!
         
-        if the city is infected and random.rand() < p_cure:
+        if the city is infected and random.random() < p_cure:
             cure the city!
          
     Make sure that city 0 *always* has zombies. It can't be cured. 
    
-   So, what's going on there? Well, ``random.rand()`` isn't so much pseudocode as actual Python code. It generates a random number between 0 and 1 every time you call it. Think of it like rolling dice. The parameter ``p_spread`` is the *probability of the zombie plague spreading* and the parameter ``p_cure`` is the probability of the plague being cured. For starters use values of 0.5 for ``p_spread`` and 0.0 for ``p_cure`` while you're getting things working. We'll play with these later. (Note: a value of 0.0 means it will never happen, and a value of 1.0 will mean that it always happens.)   
+   So, what's going on there? Well, ``random.random()`` isn't so much pseudocode as actual Python code. It generates a random number between 0 and 1 every time you call it. Think of it like rolling dice. The parameter ``p_spread`` is the *probability of the zombie plague spreading* and the parameter ``p_cure`` is the probability of the plague being cured. For starters use values of 0.5 for ``p_spread`` and 0.0 for ``p_cure`` while you're getting things working. We'll play with these later. (Note: a value of 0.0 means it will never happen, and a value of 1.0 will mean that it always happens.)   
    
-   To help explain the whole *probability* bit better, imagine you had a 10 sided die and a probability to spread of 0.8 (80%). So, think about it this way... we have an 8/10 chance to spread (80%). So if we roll the die and a 2 pops up, we will spread. We roll again, and a 7 pops up, we spread. Roll and a 1 pops up, we spread. Roll and a 9 pops up, we do **not** spread. That's what we're doing here. But instead of a die, we have ``random.rand()``.   
+   To help explain the whole *probability* bit better, imagine you had a 10 sided die and a probability to spread of 0.8 (80%). So, think about it this way... we have an 8/10 chance to spread (80%). So if we roll the die and a 2 pops up, we will spread. We roll again, and a 7 pops up, we spread. Roll and a 1 pops up, we spread. Roll and a 9 pops up, we do **not** spread. That's what we're doing here. But instead of a die, we have ``random.random()``.   
    
    .. warning::
    


### PR DESCRIPTION
### Related Issues or PRs
Closes #82 

### What
Change `numpy.random` to just be `random`
Mention `enumerate` since it would make using `cure` easier
Say `random.choice` because it's a better function for what they need.

### Why
Makes the assignment simpler while not impacting any actual learning objectives. Sure, arguably there are some that get lost, and the biggest would be focusing on not mixing up indices and list values, but whatever. 

### Additional Notes
DO NOT MERGE UNTIL AFTER ASSIGNMENT IS SUBMITTED BY STUDENTS. 
