### PR TITLE
:robot: Update workflow following restructuring

### DIFF
--- a/.github/workflows/sphinx-build.yml
+++ b/.github/workflows/sphinx-build.yml
@@ -25,7 +25,7 @@ jobs:
         python -m pip install -r requirements.txt
     - name: Sphinx Build
       run: |
-        sphinx-build -b html source/ out/
+        sphinx-build -b html site/ out/
     - name: Upload Build Artifact
       uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
### What
Change build source from `source` to `site` 

### Why
It was named that in the restructure. Also, github wouldn't let me change it locally? idk. whatever. 

### Additional Notes
This is because my access token did not include workflows in its scope. I'm looking for a quick workaround for this time. 