### PR TITLE
🤖:memo: Add Dependabot to repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+- package-ecosystem: pip
+  directory: /
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 100
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 100


### PR DESCRIPTION
### Related Issues or PRs
As suggested by @twentylemon in #115. 

### What
Add dependabot to repo.

### Why
Keep things up to date. Further, it would have already solved one of my early issues. 

### How
Stole from [duckbot](https://github.com/duck-dynasty/duckbot/blob/main/.github/dependabot.yml). 