### PR TITLE
🐛 Functions Comments emphasize `:`

### DIFF
--- a/site/topics/functions/functions.rst
+++ b/site/topics/functions/functions.rst
@@ -529,8 +529,8 @@ Docstring
         """
         Convert a temperature from Celsius units to Fahrenheit units.
 
-        @param temp_in_celsius: The temperature in Celsius to be converted.
-        @return: The temperature in Fahrenheit.
+        :param temp_in_celsius: The temperature in Celsius to be converted.
+        :return: The temperature in Fahrenheit.
         """
         partial_conversion = temp_in_celsius * 9/5
         temp_in_fahrenheit = partial_conversion + 32
@@ -540,7 +540,12 @@ Docstring
 * The stuff between the ``"""`` is the docstring and should appear immediately after the ``def`` line
 * It explains what the function does in plane English
 * It explains what each parameter is
+
+    * Mind the use of ``:``\s
+
 * If the function ``return``\s something, then explain that too
+
+    * Mind the use of ``:``\s here too
 
 * This may feel like a lot of work, especially with such a simple function in the above example
 * But having these describing the functions makes it easier for anyone looking at your code

--- a/site/topics/functions/functions.rst
+++ b/site/topics/functions/functions.rst
@@ -529,8 +529,8 @@ Docstring
         """
         Convert a temperature from Celsius units to Fahrenheit units.
 
-        :param temp_in_celsius: The temperature in Celsius to be converted.
-        :return: The temperature in Fahrenheit.
+        @param temp_in_celsius: The temperature in Celsius to be converted.
+        @return: The temperature in Fahrenheit.
         """
         partial_conversion = temp_in_celsius * 9/5
         temp_in_fahrenheit = partial_conversion + 32


### PR DESCRIPTION
### What
Fix the docstring details --- change the first `:` to an `@`.

### Why
~I guess the `@` is more correct? At least that's what pycharm says, so I trust that.~
PyCharm seems to suggest the `@`, but I can't find details on that actually being standard or anything. Either way, I'll go with what PyCharm says as it likely has more method to the madness than I do. 