### PR TITLE
:bug: © 2021 -> 2022 🔬 

### DIFF
--- a/site/conf.py
+++ b/site/conf.py
@@ -42,7 +42,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "CSCI 161"
-copyright = "2021, James Hughes, Taras Mychaskiw, & Jean-Alexis Delamer"
+copyright = "2022, James Hughes, Taras Mychaskiw, & Jean-Alexis Delamer"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
### What
Change year to 2022. 

### Why
Because it's 2022. 

### Additional Notes
Only changing it to 2022 because of the significant changes taking place. 