### PR TITLE
📝 Update Issue Template 🔬 

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,29 +1,22 @@
 :new: :bomb: :mortar_board: :memo: :robot: :lipstick: :bug: :telescope: :art: Add relevant emojis to title. [See style guide.](https://github.com/jameshughes89/cs101/blob/main/CONTRIBUTING.md#style-guidelines).
 
 ### Related Issues or PRs
-
 Replace this text with links to issues and other PRs. [Link with a keyword if you can.](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue)
 
 ### What
-
 Replace this text with a detailed description of what the issue or idea/suggestion is.
 
 ### Why
-
 Replace this text with a detailed description of why this is important.
 
 ### Where
-
 Replace this text with a detailed description of where the issue is or where it should be addressed.
 
 ### How
-
 Replace this text with a detailed description of any suggestions on how to address.
 
 ### Reproduce
-
 If applicable, replace this text with a detailed description of how to reproduce a bug.
 
 ### Additional Notes
-
 If applicable, replace this text with additional notes.


### PR DESCRIPTION
### What
Update the issue template to get rid of the new line. 

### Why
The extra newline after the heading and the text is annoying. CS102 already has it without the newline. 

### Additional Notes
Will have a separate PR for the PR template. 