### PR TITLE
🐛 FileIO remove `+` in activity name 🔬 🔬 

### DIFF
--- a/site/topics/fileIO/fileIO.rst
+++ b/site/topics/fileIO/fileIO.rst
@@ -189,7 +189,7 @@ Reading a CSV File
     <iframe width="560" height="315" src="https://www.youtube.com/embed/HUHqBtNWJo8" frameborder="0" allowfullscreen></iframe>
 
 
-.. admonition:: Activity+
+.. admonition:: Activity
     :class: activity
 
     #. Download :download:`this csv file <airports.csv>` to your computer and then upload it to Colab.


### PR DESCRIPTION
### What
Remove the `+` 

### Why
It's Unnecessary 

### Additional Notes
`+` were/are used to indicate that it is a particularly difficult activity, but this one isn't really. 
