### PR TITLE
🆕 Circle magic methods

### DIFF
--- a/src/circle.py
+++ b/src/circle.py
@@ -42,15 +42,46 @@ class Circle:
         """
         return 2 * math.pi * self.radius
 
+    def __eq__(self, other) -> bool:
+        """
+        Check if the Circle (self) is equal to the parameter Circle other. Circles are equal if they have the same
+        radius.
+
+        This is a "magic method" that can be used with `==`.
+
+        :param other: A Circle to be compared to self Circle
+        :type other: Circle
+        :return: A boolean indicating if the two Circles are equivalent
+        """
+        if isinstance(other, Circle):
+            return self.radius == other.radius
+        return False
+
+    def __repr__(self) -> str:
+        """
+        Generate and return a string representation of the Circle object.
+
+        This os a "magic method" that can be used with `str(some_circle)` or for printing.
+
+        :return: A string representation of the Circle
+        :rtype: string
+        """
+        return f"Circle(radius={self.radius})"
+
 
 circle_0 = Circle(0)
 assert 0 == circle_0.radius
 assert 0 == circle_0.diameter()
 assert 0 == circle_0.area()
 assert 0 == circle_0.circumference()
+assert "Circle(radius=0)" == str(circle_0)
 
 circle_10 = Circle(10)
 assert 10 == circle_10.radius
 assert 20 == circle_10.diameter()
 assert 0.001 > abs(circle_10.area() - 314.1592)
 assert 0.001 > abs(circle_10.circumference() - 62.8319)
+assert "Circle(radius=10)" == str(circle_10)
+
+assert circle_10 == Circle(10)
+assert circle_0 != circle_10

--- a/test/test_circle.py
+++ b/test/test_circle.py
@@ -47,3 +47,21 @@ class TestCircle(unittest.TestCase):
     def test_setting_radius_to_20_returns_correct_circumference(self):
         self.circle_0.radius = 20
         self.assertAlmostEqual(125.6637061, self.circle_0.circumference(), 5)
+
+    def test_equals_on_equal_circles_returns_true(self):
+        circle_a = Circle(1)
+        circle_b = Circle(1)
+        self.assertTrue(circle_a == circle_b)
+
+    def test_equals_on_not_equal_circles_returns_false(self):
+        circle_a = Circle(1)
+        circle_b = Circle(2)
+        self.assertFalse(circle_a == circle_b)
+
+    def test_equal_on_circle_and_string_returns_false(self):
+        circle = Circle(1)
+        self.assertFalse("Circle(1)" == circle)
+
+    def test_repr_arbitrary_circle_returns_correct_string(self):
+        circle = Circle(1)
+        self.assertFalse("Circle(1)" == str(circle))


### PR DESCRIPTION
### Related Issues or PRs
Adds to #278 

### What
Include `__eq__`  and `__repr__`.

### Why
These methods will **not** included in the Topic focusing on the `Circle` class, but will be added to the Topic covering the `Point` class when those magic methods are used --- something like "could've totally added these to our Circle class too!"

### Testing
:+1: