### PR TITLE
:bug: Lab Refs and Lists remove extra section title 🔬 

### DIFF
--- a/site/labs/references/references.rst
+++ b/site/labs/references/references.rst
@@ -105,9 +105,6 @@ Before Kattis
 Kattis Problems
 ===============
 
-Kattis Problems
-===============
-
 * You should be using a scrap piece of paper to work out the ideas for the following problems
 
     * The problems you are to solve are getting too complex to try to solve by just coding


### PR DESCRIPTION
### What
Remove the duplicate section title for Kattis problems. 