### PR TITLE
📝 Add new lines back to template 🔬 

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,22 +1,29 @@
 :new: :bomb: :mortar_board: :memo: :robot: :lipstick: :bug: :telescope: :art: Add relevant emojis to title. [See style guide.](https://github.com/jameshughes89/cs101/blob/main/CONTRIBUTING.md#style-guidelines).
 
 ### Related Issues or PRs
+
 Replace this text with links to issues and other PRs. [Link with a keyword if you can.](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue)
 
 ### What
+
 Replace this text with a detailed description of what the issue or idea/suggestion is.
 
 ### Why
+
 Replace this text with a detailed description of why this is important.
 
 ### Where
+
 Replace this text with a detailed description of where the issue is or where it should be addressed.
 
 ### How
+
 Replace this text with a detailed description of any suggestions on how to address.
 
 ### Reproduce
+
 If applicable, replace this text with a detailed description of how to reproduce a bug.
 
 ### Additional Notes
+
 If applicable, replace this text with additional notes.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,19 +5,25 @@
 If applicable, replace this text with links to issues and other PRs. [Link with a keyword if you can.](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue)
 
 ### What
+
 Replace this text with a detailed description of what the change is.
 
 ### Why
+
 Replace this text with a detailed description of why this is important.
 
 ### Where
+
 Replace this text with a detailed description of where the change is and why (should it be an aside?).
 
 ### How
+
 Replace this text with a detailed description of how it is addressed.
 
 ### Testing
+
 If applicable, replace this text with a detailed description of how changes were tested. Include manual testing.
 
 ### Additional Notes
+
 If applicable, replace this text with additional notes. Copyright concerns? etc.


### PR DESCRIPTION
### Related Issues or PRs

Undoes #231 

### What
Add the new line back to the template files. 

### Why
It was getting annoying to discard the changes to the md files every time I ran format. mdformat insists on the new line, and I looked into adding an exception to that rule for these files, but whatever, it's easier to make it shutup this way. 

Also, if the good people of _mdformat_ believe the new line is important, I will yield to them. 