### PR TITLE
:new: Add type hints to existing classes

### DIFF
--- a/src/circle.py
+++ b/src/circle.py
@@ -42,7 +42,7 @@ class Circle:
         """
         return 2 * math.pi * self.radius
 
-    def __eq__(self, other) -> bool:
+    def __eq__(self, other: "Circle") -> bool:
         """
         Check if the Circle (self) is equal to the parameter Circle other. Circles are equal if they have the same
         radius.

--- a/src/course.py
+++ b/src/course.py
@@ -1,20 +1,23 @@
+from student import Student
+
+
 class Course:
     """
     A collection of students enrolled in a course. This class manages the individual Students and provides simple
     enrollment details.
     """
 
-    def __init__(self, course_name):
+    def __init__(self, course_name: str):
         self.course_name = course_name
         self._students = []
 
     def size(self) -> int:
         return len(self._students)
 
-    def add(self, student):
+    def add(self, student: Student):
         self._students.append(student)
 
-    def find(self, student) -> int:
+    def find(self, student: Student) -> int:
         """
         Returns the index of the first occurrence of a given Student if it exists. If it does not exist, return a
         sentinel value of -1.
@@ -29,7 +32,7 @@ class Course:
                 return i
         return -1
 
-    def remove(self, student):
+    def remove(self, student: Student):
         """
         Remove the first occurence of the specified student from the collection. If the student does not exist, raise
         an exception.

--- a/src/point3d.py
+++ b/src/point3d.py
@@ -6,7 +6,7 @@ class Point3D:
     A class for representing points in a three dimensional (3D) space.
     """
 
-    def __init__(self, x, y, z):
+    def __init__(self, x: float, y: float, z: float):
         self.x = x
         self.y = y
         self.z = z
@@ -20,7 +20,7 @@ class Point3D:
         """
         return self.distance_from_point(Point3D(0, 0, 0))
 
-    def distance_from_point(self, other) -> float:
+    def distance_from_point(self, other: "Point3D") -> float:
         """
         Calculate the Euclidean distance from this Point3D (self) and the Point3D passed as a parameter.
 
@@ -31,7 +31,7 @@ class Point3D:
         """
         return math.sqrt((self.x - other.x) ** 2 + (self.y - other.y) ** 2 + (self.z - other.z) ** 2)
 
-    def find_midpoint(self, other):
+    def find_midpoint(self, other: "Point3D") -> "Point3D":
         """
         Return a new Point3D that is the midpoint between this Point3D (self) and the Point3D passed as a parameter.
 
@@ -45,7 +45,7 @@ class Point3D:
         midpoint_z = (self.z - other.z) / 2 + other.z
         return Point3D(midpoint_x, midpoint_y, midpoint_z)
 
-    def __eq__(self, other) -> bool:
+    def __eq__(self, other: "Point3D") -> bool:
         """
         Check if the self Point3D is equal to the Point3D passed as a parameter. Points3D are considered equal if they
         have the same x, y, and z values.

--- a/src/student.py
+++ b/src/student.py
@@ -4,12 +4,12 @@ class Student:
     and checking equality.
     """
 
-    def __init__(self, first_name, last_name, student_number):
+    def __init__(self, first_name: str, last_name: str, student_number: int):
         self.first_name = first_name
         self.last_name = last_name
         self.student_number = student_number
 
-    def __eq__(self, other) -> bool:
+    def __eq__(self, other: "Student") -> bool:
         """
         Two students are considered equal if their student numbers are the same. This assumes student numbers are unique
         among students.


### PR DESCRIPTION
### Related Issues or PRs
As mentioned in #295 by @twentylemon, turns out custom classes do not require `typing` 

### What

Add type hints to the classes made. 

### Where

All the classes made so far 

### How

In some cases the type hints needed to be added as string literals since they were of the class that was being defined, otherwise they were just added. I believe there is 

### Testing

:+1: for good measure. 