### PR TITLE
🐛 Objects Lab fix download and topic references 🔬 

### DIFF
--- a/site/labs/objects/objects.rst
+++ b/site/labs/objects/objects.rst
@@ -22,9 +22,9 @@ Objects
 Pre Lab Exercises
 =================
 
-* Have a working implementation of the ``Circle`` class from :doc:`lecture </topics/objects/objects1>`
+* Have a working implementation of the ``Circle`` class from :doc:`lecture </topics/objects/introduction>`
 
-    * You can obtain the source code from :download:`here </src/circle.py>`
+    * You can obtain the source code from :download:`here <../../../src/circle.py>`
     * Yes, this week's pre-lab exercise is intended to be simple
     * It will provide a nice template for all the classes you will make in this lab
 


### PR DESCRIPTION
### What

1. Fix the reference to the intro topic of objects
2. Fix the download file reference in the objects lab 

### Why

B-B-B-B-Busted