### PR TITLE
:new: ❓ Objects Intro Topic add class to top of code bits 🔬 

### DIFF
--- a/site/topics/objects/introduction.rst
+++ b/site/topics/objects/introduction.rst
@@ -204,6 +204,10 @@ Functionality and Methods
 .. code-block:: python
     :linenos:
 
+    class Circle:
+
+        # init and/or other methods not shown for brevity
+
         def diameter(self) -> float:
             """
             Calculate and return the diameter of the Circle based on its radius.
@@ -224,6 +228,10 @@ Functionality and Methods
 
 .. code-block:: python
     :linenos:
+
+    class Circle:
+
+        # init and/or other methods not shown for brevity
 
         def area(self) -> float:
             """


### PR DESCRIPTION
### What

Add the class keyword and class name to the top of the relevant code bits shown.

```python
    class Circle:

        # init and/or other methods not shown for brevity
```

### Why

Emphasize that the code is _within_ the class definition (indented). Based on previous years, students mix this up (though, they also mix up by putting functions in other functions all the time, so the issue may be _attention to detail_ and not so much needing to be explicitly shown). 

### Additional Notes

Marked as questionable as I am not sure this is the best way to emphasize this.