### PR TITLE
💄 Change test class name order

### DIFF
--- a/test/test_circle.py
+++ b/test/test_circle.py
@@ -3,7 +3,7 @@ import unittest
 from src.circle import Circle
 
 
-class TestCircle(unittest.TestCase):
+class CircleTest(unittest.TestCase):
     def setUp(self):
         self.circle_0 = Circle(0)
         self.circle_10 = Circle(10)

--- a/test/test_course.py
+++ b/test/test_course.py
@@ -4,7 +4,7 @@ from src.course import Course
 from src.student import Student
 
 
-class TestCourse(TestCase):
+class CourseTest(TestCase):
     def test_course_name_returns_correct_name(self):
         course = Course("CS101")
         self.assertEqual("CS101", course.course_name)

--- a/test/test_functions_topic.py
+++ b/test/test_functions_topic.py
@@ -8,7 +8,7 @@ from src.functions_topic import (
 )
 
 
-class TestFunctionsTopic(unittest.TestCase):
+class FunctionsTopicTest(unittest.TestCase):
     def test_celsius_to_fahrenheit_positive_celsius_values_returns_correct_fahrenheit_value(self):
         self.assertEqual(104, celsius_to_fahrenheit(40))
 

--- a/test/test_if_else_topic.py
+++ b/test/test_if_else_topic.py
@@ -12,7 +12,7 @@ from src.if_else_topic import (
 )
 
 
-class TestIfElseTopic(unittest.TestCase):
+class IfElseTopicTest(unittest.TestCase):
     def test_smush_positive_parameter_returns_half(self):
         self.assertEqual(5, smush(10))
 

--- a/test/test_lists_topic.py
+++ b/test/test_lists_topic.py
@@ -3,7 +3,7 @@ import unittest
 from src.lists_topic import contains_while, index_of_for, my_sum
 
 
-class TestListsTopic(unittest.TestCase):
+class ListsTopicTest(unittest.TestCase):
     def test_contains_while_search_in_empty_list_returns_false(self):
         self.assertFalse(contains_while("a", []))
 

--- a/test/test_loops_topic.py
+++ b/test/test_loops_topic.py
@@ -5,7 +5,7 @@ import unittest.mock
 from src.loops_topic import factorial, int_sum, int_sum_print, sum_even_numbers
 
 
-class TestLoopsTopic(unittest.TestCase):
+class LoopsTopicTest(unittest.TestCase):
     def test_factorial_0_returns_1(self):
         self.assertEqual(1, factorial(0))
 

--- a/test/test_point3d.py
+++ b/test/test_point3d.py
@@ -3,7 +3,7 @@ import unittest
 from src.point3d import Point3D
 
 
-class TestPoint3D(unittest.TestCase):
+class Point3DTest(unittest.TestCase):
     def test_point_0_0_0_has_x_0(self):
         point = Point3D(0, 0, 0)
         self.assertEqual(0, point.x)

--- a/test/test_sphere.py
+++ b/test/test_sphere.py
@@ -4,7 +4,7 @@ from src.point3d import Point3D
 from src.sphere import Sphere
 
 
-class TestSphere(unittest.TestCase):
+class SphereTest(unittest.TestCase):
     def test_sphere_centre_point_returns_correct_point3D(self):
         sphere = Sphere(Point3D(0, 0, 0), 1)
         self.assertEqual(Point3D(0, 0, 0), sphere.centre_point)

--- a/test/test_strings_topic.py
+++ b/test/test_strings_topic.py
@@ -10,7 +10,7 @@ from src.strings_topic import (
 )
 
 
-class TestStringsTopic(unittest.TestCase):
+class StringsTopicTest(unittest.TestCase):
     @unittest.mock.patch("sys.stdout", new_callable=io.StringIO)
     def test_vertical_print_while_empty_string_prints_nothing(self, mock_stdout):
         vertical_print_while("")

--- a/test/test_student.py
+++ b/test/test_student.py
@@ -3,7 +3,7 @@ import unittest
 from src.student import Student
 
 
-class TestStudent(unittest.TestCase):
+class StudentTest(unittest.TestCase):
     def test_student_first_name_returns_correct_first_name(self):
         student = Student("Bob", "Smith", 123456789)
         self.assertEqual("Bob", student.first_name)


### PR DESCRIPTION
### Related Issues or PRs
closes #281

### What

Change the test names to be XTest instead of TestX

### Why

Although there appears to be no "standard", @twentylemon had some method to the madness that made sense, so that's the idea. 

### Testing

:+1: