### PR TITLE
💣 Debug Lab remove link/ref from index

### DIFF
--- a/site/index.rst
+++ b/site/index.rst
@@ -147,7 +147,6 @@ The Math, Stats, and CS Society now has a time and location for our free tutoria
     labs/lists/1d-lists
     labs/lists/2d-lists
     labs/lists/references
-    labs/debug/debug
     labs/objects/objects
     labs/objects/data-structures
     labs/recursion/recursion


### PR DESCRIPTION
### Related Issues or PRs
Was removed in #286, but came back somehow 🤷 

### What

Remove the link to the debug lab from the index page. 
