### PR TITLE
:new: Objects Topic Shuffle make new topic and move other topics around

### DIFF
--- a/site/index.rst
+++ b/site/index.rst
@@ -125,6 +125,7 @@ The Math, Stats, and CS Society now has a time and location for our free tutoria
     topics/exceptions/exceptions
     topics/objects/introduction
     topics/objects/methods
+    topics/objects/interacting-objects
     topics/testing/unittest
     topics/objects/data-structures
     topics/searching/searching

--- a/site/topics/objects/data-structures.rst
+++ b/site/topics/objects/data-structures.rst
@@ -1,6 +1,6 @@
-*******************************
-Objects III --- Data Structures
-*******************************
+******************************
+Objects IV --- Data Structures
+******************************
 
 * We have spent much of the course learning how to write algorithms
 * But we also saw a few data structures

--- a/site/topics/objects/interacting-objects.rst
+++ b/site/topics/objects/interacting-objects.rst
@@ -12,6 +12,8 @@ Objects III --- Interacting Objects
 
 * Although there is nothing wrong with the original ``Sphere`` implementation, let's consider that
 
+    * It will make our ``Sphere`` class simpler and easier to understand
+    * It allows us to write the methods at a higher-level of abstraction since can deal with ``Point3D`` objects instead of individual coordinates
     * If we wanted to make other three dimensional shapes, they could use something like a ``Point3D`` class to represent their position
     * It allows us to abstract and delegate some functionality to another class
     * It will help with testing since we can test the ``Point3D`` class' functionality and the ``Sphere``\s independently

--- a/site/topics/objects/interacting-objects.rst
+++ b/site/topics/objects/interacting-objects.rst
@@ -2,6 +2,19 @@
 Objects III --- Interacting Objects
 ***********************************
 
+* We completed the ``Sphere`` class in the previous topic, and it will work for our needs
+* However, there are a few things we could do to improve the design and implementation
+* One idea is to make a ``Point3D`` class to manage all the point related things
+
+    * Location in three dimensional space
+    * Distance between points
+    * Equality on points
+
+* Although there is nothing wrong with the original ``Sphere`` implementation, let's consider that
+
+    * If we wanted to make other three dimensional shapes, they could use something like a ``Point3D`` class to represent their position
+    * It allows us to abstract and delegate some functionality to another class
+    * It will help with testing since we can test the ``Point3D`` class' functionality and the ``Sphere``\s independently
 
 
 Point3D Class

--- a/site/topics/objects/interacting-objects.rst
+++ b/site/topics/objects/interacting-objects.rst
@@ -1,0 +1,50 @@
+***********************************
+Objects III --- Interacting Objects
+***********************************
+
+
+
+Point3D Class
+=============
+
+
+Constructor and Attributes
+--------------------------
+
+
+Methods
+-------
+
+
+Magic Methods
+^^^^^^^^^^^^^
+
+
+
+Testing
+-------
+
+
+
+Sphere Class
+============
+
+
+Constructor and Attributes
+--------------------------
+
+
+Methods
+-------
+
+
+
+Testing
+-------
+
+
+
+For Next Class
+==============
+
+* Read `Chapter 21 of the text <http://openbookproject.net/thinkcs/python/english3e/even_more_oop.html>`_


### PR DESCRIPTION
### Related Issues or PRs

As discussed with @twentylemon  in #315 

### What

1. Make a new objects topic to come after the `Sphere` implementation
2. Introduce the topic
3. Move the Data structures topic back

### Why

1. The flow of the content will be improved

### Additional Notes

The existing PRs (#315, #316, #317, #318) will be updated by moving the content to this topic after this PR is merged.
