### PR TITLE
:bug: Sphere Class correct type hint 🔬 

### DIFF
--- a/src/sphere.py
+++ b/src/sphere.py
@@ -23,7 +23,7 @@ class Sphere:
     def volume(self) -> float:
         return (4 / 3) * math.pi * self.radius**3
 
-    def distance_between_centres(self, other: Point3D) -> float:
+    def distance_between_centres(self, other: "Sphere") -> float:
         """
         Calculate and return the distance between the centres of two Spheres.
 


### PR DESCRIPTION
### What

Change the type hint from `Point3D` to `"Sphere"` 

### Why

It should be a `Sphere`, not a `Point3D`. 

### Additional Notes

I believe this was pointed out by @twentylemon in a previous PR, but this one got missed. 
