### PR TITLE
🎓 Original Sphere Class make a class containing the `Sphere` before `Point3D` 

### DIFF
--- a/src/sphere_original.py
+++ b/src/sphere_original.py
@@ -1,0 +1,69 @@
+import math
+
+from src.point3d import Point3D
+
+
+class SphereOriginal:
+    """
+    Class for managing Spheres within a 3D space. This includes tracking it's location in three dimensional space and
+    radius. Additionally, it allows for some basic geometry calculations, distance measurements between Spheres, and
+    checking if two Spheres overlap.
+    """
+
+    def __init__(self, x: float, y: float, z: float, radius: float):
+        self.x = x
+        self.y = y
+        self.z = z
+        self.radius = radius
+
+    def diameter(self) -> float:
+        return 2 * self.radius
+
+    def surface_area(self) -> float:
+        return 4 * math.pi * self.radius**2
+
+    def volume(self) -> float:
+        return (4 / 3) * math.pi * self.radius**3
+
+    def distance_between_centres(self, other: Point3D) -> float:
+        """
+        Calculate and return the distance between the centres of two Spheres.
+
+        :param other: Sphere whose centre to find the distance to from the self Sphere.
+        :type other: Sphere
+        :return: Distance between the Sphere centres.
+        :rtype: float
+        """
+        return self.centre_point.distance_from_point(other.centre_point)
+
+    def distance_between_edges(self, other: "Sphere") -> float:
+        """
+        Calculate and return the distance between the edges of two Spheres. If the value is negative, the two Spheres
+        overlap.
+
+        :param other: Sphere whose edge to find the distance to from the self Sphere.
+        :type other: Sphere
+        :return: Distance between the Sphere edges.
+        :rtype: float
+        """
+        return self.distance_between_centres(other) - self.radius - other.radius
+
+    def overlaps(self, other: "Sphere") -> bool:
+        """
+        Determine if two Sphere objects overlap within the 3D space. Two Spheres that are touching (distance of 0
+        between edges) are considered overlapping.
+
+        :param other: Sphere to check if it overlaps the self Sphere overlaps
+        :type other: Sphere
+        :return: Boolean indicating if the two Spheres overlap
+        :rtype: bool
+        """
+        return self.distance_between_edges(other) <= 0
+
+    def __eq__(self, other) -> bool:
+        if isinstance(other, Sphere):
+            return self.radius == other.radius and self.centre_point == other.centre_point
+        return False
+
+    def __repr__(self) -> str:
+        return f"Sphere({self.centre_point}, {self.radius})"

--- a/src/sphere_original.py
+++ b/src/sphere_original.py
@@ -67,3 +67,34 @@ class Sphere:
 
     def __repr__(self) -> str:
         return f"Sphere({self.x}, {self.y}, {self.z}, {self.radius})"
+
+
+sphere_origin_0 = Sphere(0, 0, 0, 0)
+assert 0 == sphere_origin_0.x
+assert 0 == sphere_origin_0.y
+assert 0 == sphere_origin_0.z
+assert 0 == sphere_origin_0.radius
+assert 0 == sphere_origin_0.diameter()
+assert 0 == sphere_origin_0.surface_area()
+assert 0 == sphere_origin_0.volume()
+assert 0 == sphere_origin_0.distance_between_centres(Sphere(0, 0, 0, 0))
+assert 0 == sphere_origin_0.distance_between_edges(Sphere(0, 0, 0, 0))
+assert True == sphere_origin_0.overlaps(Sphere(0, 0, 0, 0))
+assert True == (sphere_origin_0 == Sphere(0, 0, 0, 0))
+assert False == (sphere_origin_0 == Sphere(0, 0, 0, 1))
+assert "Sphere(0, 0, 0, 0)" == str(sphere_origin_0)
+
+sphere = Sphere(1, 2, 3, 4)
+assert 1 == sphere.x
+assert 2 == sphere.y
+assert 3 == sphere.z
+assert 4 == sphere.radius
+assert 8 == sphere.diameter()
+assert 0.01 > abs(sphere.surface_area() - 201.06)
+assert 0.01 > abs(sphere.volume() - 268.08)
+assert 0.01 > abs(sphere.distance_between_centres(Sphere(0, 0, 0, 0)) - 3.74)
+assert 0.01 > abs(sphere.distance_between_edges(Sphere(0, 0, 0, 0)) - (-0.26))
+assert True == sphere.overlaps(Sphere(0, 0, 0, 0))
+assert False == (sphere == Sphere(0, 0, 0, 0))
+assert True == (sphere == Sphere(1, 2, 3, 4))
+assert "Sphere(1, 2, 3, 4)" == str(sphere)

--- a/src/sphere_original.py
+++ b/src/sphere_original.py
@@ -34,7 +34,7 @@ class Sphere:
         :return: Distance between the Sphere centres.
         :rtype: float
         """
-        return math.sqrt((self.x - other.x)**2 + (self.y - other.y)**2 + (self.z - other.z)**2)
+        return math.sqrt((self.x - other.x) ** 2 + (self.y - other.y) ** 2 + (self.z - other.z) ** 2)
 
     def distance_between_edges(self, other: "Sphere") -> float:
         """

--- a/src/sphere_original.py
+++ b/src/sphere_original.py
@@ -3,7 +3,7 @@ import math
 from src.point3d import Point3D
 
 
-class SphereOriginal:
+class Sphere:
     """
     Class for managing Spheres within a 3D space. This includes tracking it's location in three dimensional space and
     radius. Additionally, it allows for some basic geometry calculations, distance measurements between Spheres, and
@@ -25,7 +25,7 @@ class SphereOriginal:
     def volume(self) -> float:
         return (4 / 3) * math.pi * self.radius**3
 
-    def distance_between_centres(self, other: Point3D) -> float:
+    def distance_between_centres(self, other: "Sphere") -> float:
         """
         Calculate and return the distance between the centres of two Spheres.
 
@@ -34,7 +34,7 @@ class SphereOriginal:
         :return: Distance between the Sphere centres.
         :rtype: float
         """
-        return self.centre_point.distance_from_point(other.centre_point)
+        return math.sqrt((self.x - other.x)**2 + (self.y - other.y)**2 + (self.z - other.z)**2)
 
     def distance_between_edges(self, other: "Sphere") -> float:
         """
@@ -62,8 +62,8 @@ class SphereOriginal:
 
     def __eq__(self, other) -> bool:
         if isinstance(other, Sphere):
-            return self.radius == other.radius and self.centre_point == other.centre_point
+            return self.x == other.x and self.y == other.y and self.z == other.z and self.radius == other.radius
         return False
 
     def __repr__(self) -> str:
-        return f"Sphere({self.centre_point}, {self.radius})"
+        return f"Sphere({self.x}, {self.y}, {self.z}, {self.radius})"

--- a/test/test_sphere_original.py
+++ b/test/test_sphere_original.py
@@ -59,10 +59,10 @@ class SphereOriginalTest(unittest.TestCase):
 
     def test_distance_between_centres_various_spheres_returns_correct_distance(self):
         cases = [
-            (Sphere(0, 0, 0, 1), Sphere(Point3D(0, 0, 0), 1)),
-            (Sphere(0, 0, 0, 1), Sphere(Point3D(1, 1, 1), 1)),
-            (Sphere(1, 1, 1, 1), Sphere(Point3D(1, 1, 1), 10)),
-            (Sphere(-1, -1, -1, 1), Sphere(Point3D(1, 1, 1), 10)),
+            (Sphere(0, 0, 0, 1), Sphere(0, 0, 0, 1)),
+            (Sphere(0, 0, 0, 1), Sphere(1, 1, 1, 1)),
+            (Sphere(1, 1, 1, 1), Sphere(1, 1, 1, 10)),
+            (Sphere(-1, -1, -1, 1), Sphere(1, 1, 1, 10)),
         ]
         expecteds = [0, 1.732051, 0, 3.464102]
         for (case, expect) in zip(cases, expecteds):
@@ -71,10 +71,10 @@ class SphereOriginalTest(unittest.TestCase):
 
     def test_distance_between_edges_various_spheres_returns_correct_distance(self):
         cases = [
-            (Sphere(0, 0, 0, 1), Sphere(Point3D(0, 0, 0), 1)),
-            (Sphere(0, 0, 0, 1), Sphere(Point3D(1, 1, 1), 1)),
-            (Sphere(0, 0, 0, 1), Sphere(Point3D(10, 10, 10), 1)),
-            (Sphere(-1, -1, -1, 1), Sphere(Point3D(10, 10, 10), 10)),
+            (Sphere(0, 0, 0, 1), Sphere(0, 0, 0, 1)),
+            (Sphere(0, 0, 0, 1), Sphere(1, 1, 1, 1)),
+            (Sphere(0, 0, 0, 1), Sphere(10, 10, 10, 1)),
+            (Sphere(-1, -1, -1, 1), Sphere(10, 10, 10, 10)),
         ]
         expecteds = [-2, -0.267949, 15.320508, 8.052559]
         for (case, expect) in zip(cases, expecteds):
@@ -83,11 +83,11 @@ class SphereOriginalTest(unittest.TestCase):
 
     def test_overlaps_various_spheres_returns_correct_boolean(self):
         cases = [
-            (Sphere(0, 0, 0), 1, Sphere(Point3D(0, 0, 0), 1)),
-            (Sphere(0, 0, 0), 1, Sphere(Point3D(1, 1, 1), 1)),
-            (Sphere(0, 0, 0), 1, Sphere(Point3D(10, 10, 10), 1)),
-            (Sphere(-1, -1, -1, 10), Sphere(Point3D(10, 10, 10), 10)),
-            (Sphere(-1, 1, 4, 5), Sphere(Point3D(-2, -3, -4), 4)),
+            (Sphere(0, 0, 0, 1), Sphere(0, 0, 0, 1)),
+            (Sphere(0, 0, 0, 1), Sphere(1, 1, 1, 1)),
+            (Sphere(0, 0, 0, 1), Sphere(10, 10, 10, 1)),
+            (Sphere(-1, -1, -1, 10), Sphere(10, 10, 10, 10)),
+            (Sphere(-1, 1, 4, 5), Sphere(-2, -3, -4, 4)),
         ]
         expecteds = [True, True, False, True, True]
         for (case, expect) in zip(cases, expecteds):
@@ -110,4 +110,4 @@ class SphereOriginalTest(unittest.TestCase):
 
     def test_repr_arbitrary_sphere_returns_correct_string(self):
         sphere = Sphere(1, 2, 3, 4)
-        self.assertEqual("Sphere(, 2, 3, 4)", str(sphere))
+        self.assertEqual("Sphere(1, 2, 3, 4)", str(sphere))

--- a/test/test_sphere_original.py
+++ b/test/test_sphere_original.py
@@ -8,11 +8,11 @@ class SphereOriginalTest(unittest.TestCase):
         sphere = Sphere(0, 1, 2, 1)
         self.assertEqual(0, sphere.x)
 
-    def test_sphere_y_returns_correct_x(self):
+    def test_sphere_y_returns_correct_y(self):
         sphere = Sphere(0, 1, 2, 1)
         self.assertEqual(1, sphere.y)
 
-    def test_sphere_z_returns_correct_x(self):
+    def test_sphere_z_returns_correct_z(self):
         sphere = Sphere(0, 1, 2, 1)
         self.assertEqual(2, sphere.z)
 

--- a/test/test_sphere_original.py
+++ b/test/test_sphere_original.py
@@ -1,0 +1,105 @@
+import unittest
+
+from src.point3d import Point3D
+from src.sphere_original import Sphere
+
+
+class SphereOriginalTest(unittest.TestCase):
+    def test_sphere_centre_point_returns_correct_point3D(self):
+        sphere = Sphere(0, 0, 0, 1)
+        self.assertEqual(Point3D(0, 0, 0, sphere.centre_point)
+
+    def test_sphere_radius_returns_correct_radius(self):
+        sphere = Sphere(Point3D(0, 0, 0), 1)
+        self.assertEqual(1, sphere.radius)
+
+    def test_diameter_various_spheres_returns_correct_diameter(self):
+        cases = [
+            Sphere(Point3D(0, 0, 0), 0),
+            Sphere(Point3D(0, 0, 0), 1),
+            Sphere(Point3D(1, 1, 1), 0),
+            Sphere(Point3D(10, 11, 12), 10),
+        ]
+        expecteds = [0, 2, 0, 20]
+        for (case, expect) in zip(cases, expecteds):
+            with self.subTest(case=case, expect=expect):
+                self.assertAlmostEqual(expect, case.diameter(), 5)
+
+    def test_surface_area_various_spheres_returns_correct_surface_area(self):
+        cases = [
+            Sphere(Point3D(0, 0, 0), 0),
+            Sphere(Point3D(0, 0, 0), 1),
+            Sphere(Point3D(1, 1, 1), 0),
+            Sphere(Point3D(10, 11, 12), 10),
+        ]
+        expecteds = [0, 12.56637, 0, 1256.63706]
+        for (case, expect) in zip(cases, expecteds):
+            with self.subTest(case=case, expect=expect):
+                self.assertAlmostEqual(expect, case.surface_area(), 5)
+
+    def test_volume_various_spheres_returns_correct_volume(self):
+        cases = [
+            Sphere(Point3D(0, 0, 0), 0),
+            Sphere(Point3D(0, 0, 0), 1),
+            Sphere(Point3D(1, 1, 1), 0),
+            Sphere(Point3D(10, 11, 12), 10),
+        ]
+        expecteds = [0, 4.18879, 0, 4188.7902]
+        for (case, expect) in zip(cases, expecteds):
+            with self.subTest(case=case, expect=expect):
+                self.assertAlmostEqual(expect, case.volume(), 5)
+
+    def test_distance_between_centres_various_spheres_returns_correct_distance(self):
+        cases = [
+            (Sphere(Point3D(0, 0, 0), 1), Sphere(Point3D(0, 0, 0), 1)),
+            (Sphere(Point3D(0, 0, 0), 1), Sphere(Point3D(1, 1, 1), 1)),
+            (Sphere(Point3D(1, 1, 1), 1), Sphere(Point3D(1, 1, 1), 10)),
+            (Sphere(Point3D(-1, -1, -1), 1), Sphere(Point3D(1, 1, 1), 10)),
+        ]
+        expecteds = [0, 1.732051, 0, 3.464102]
+        for (case, expect) in zip(cases, expecteds):
+            with self.subTest(case=case, expect=expect):
+                self.assertAlmostEqual(expect, case[0].distance_between_centres(case[1]), 5)
+
+    def test_distance_between_edges_various_spheres_returns_correct_distance(self):
+        cases = [
+            (Sphere(Point3D(0, 0, 0), 1), Sphere(Point3D(0, 0, 0), 1)),
+            (Sphere(Point3D(0, 0, 0), 1), Sphere(Point3D(1, 1, 1), 1)),
+            (Sphere(Point3D(0, 0, 0), 1), Sphere(Point3D(10, 10, 10), 1)),
+            (Sphere(Point3D(-1, -1, -1), 1), Sphere(Point3D(10, 10, 10), 10)),
+        ]
+        expecteds = [-2, -0.267949, 15.320508, 8.052559]
+        for (case, expect) in zip(cases, expecteds):
+            with self.subTest(case=case, expect=expect):
+                self.assertAlmostEqual(expect, case[0].distance_between_edges(case[1]), 5)
+
+    def test_overlaps_various_spheres_returns_correct_boolean(self):
+        cases = [
+            (Sphere(Point3D(0, 0, 0), 1), Sphere(Point3D(0, 0, 0), 1)),
+            (Sphere(Point3D(0, 0, 0), 1), Sphere(Point3D(1, 1, 1), 1)),
+            (Sphere(Point3D(0, 0, 0), 1), Sphere(Point3D(10, 10, 10), 1)),
+            (Sphere(Point3D(-1, -1, -1), 10), Sphere(Point3D(10, 10, 10), 10)),
+            (Sphere(Point3D(-1, 1, 4), 5), Sphere(Point3D(-2, -3, -4), 4)),
+        ]
+        expecteds = [True, True, False, True, True]
+        for (case, expect) in zip(cases, expecteds):
+            with self.subTest(case=case, expect=expect):
+                self.assertEqual(expect, case[0].overlaps(case[1]))
+
+    def test_equals_on_equal_spheres_returns_true(self):
+        sphere_a = Sphere(Point3D(1, 2, 3), 1)
+        sphere_b = Sphere(Point3D(1, 2, 3), 1)
+        self.assertTrue(sphere_a == sphere_b)
+
+    def test_equals_on_not_equal_spheres_returns_false(self):
+        sphere_a = Sphere(Point3D(1, 2, 3), 1)
+        sphere_b = Sphere(Point3D(1, 2, 3), 2)
+        self.assertFalse(sphere_a == sphere_b)
+
+    def test_equal_on_sphere_and_string_returns_false(self):
+        sphere = Sphere(Point3D(1, 2, 3), 4)
+        self.assertFalse("Sphere(Point3D(1, 2, 3), 4)" == sphere)
+
+    def test_repr_arbitrary_sphere_returns_correct_string(self):
+        sphere = Sphere(Point3D(1, 2, 3), 4)
+        self.assertEqual("Sphere(Point3D(1, 2, 3), 4)", str(sphere))

--- a/test/test_sphere_original.py
+++ b/test/test_sphere_original.py
@@ -1,6 +1,5 @@
 import unittest
 
-from src.point3d import Point3D
 from src.sphere_original import Sphere
 
 

--- a/test/test_sphere_original.py
+++ b/test/test_sphere_original.py
@@ -5,20 +5,28 @@ from src.sphere_original import Sphere
 
 
 class SphereOriginalTest(unittest.TestCase):
-    def test_sphere_centre_point_returns_correct_point3D(self):
-        sphere = Sphere(0, 0, 0, 1)
-        self.assertEqual(Point3D(0, 0, 0, sphere.centre_point)
+    def test_sphere_x_returns_correct_x(self):
+        sphere = Sphere(0, 1, 2, 1)
+        self.assertEqual(0, sphere.x)
+
+    def test_sphere_y_returns_correct_x(self):
+        sphere = Sphere(0, 1, 2, 1)
+        self.assertEqual(1, sphere.y)
+
+    def test_sphere_z_returns_correct_x(self):
+        sphere = Sphere(0, 1, 2, 1)
+        self.assertEqual(2, sphere.z)
 
     def test_sphere_radius_returns_correct_radius(self):
-        sphere = Sphere(Point3D(0, 0, 0), 1)
+        sphere = Sphere(0, 0, 0, 1)
         self.assertEqual(1, sphere.radius)
 
     def test_diameter_various_spheres_returns_correct_diameter(self):
         cases = [
-            Sphere(Point3D(0, 0, 0), 0),
-            Sphere(Point3D(0, 0, 0), 1),
-            Sphere(Point3D(1, 1, 1), 0),
-            Sphere(Point3D(10, 11, 12), 10),
+            Sphere(0, 0, 0, 0),
+            Sphere(0, 0, 0, 1),
+            Sphere(1, 1, 1, 0),
+            Sphere(10, 11, 12, 10),
         ]
         expecteds = [0, 2, 0, 20]
         for (case, expect) in zip(cases, expecteds):
@@ -27,10 +35,10 @@ class SphereOriginalTest(unittest.TestCase):
 
     def test_surface_area_various_spheres_returns_correct_surface_area(self):
         cases = [
-            Sphere(Point3D(0, 0, 0), 0),
-            Sphere(Point3D(0, 0, 0), 1),
-            Sphere(Point3D(1, 1, 1), 0),
-            Sphere(Point3D(10, 11, 12), 10),
+            Sphere(0, 0, 0, 0),
+            Sphere(0, 0, 0, 1),
+            Sphere(1, 1, 1, 0),
+            Sphere(10, 11, 12, 10),
         ]
         expecteds = [0, 12.56637, 0, 1256.63706]
         for (case, expect) in zip(cases, expecteds):
@@ -39,10 +47,10 @@ class SphereOriginalTest(unittest.TestCase):
 
     def test_volume_various_spheres_returns_correct_volume(self):
         cases = [
-            Sphere(Point3D(0, 0, 0), 0),
-            Sphere(Point3D(0, 0, 0), 1),
-            Sphere(Point3D(1, 1, 1), 0),
-            Sphere(Point3D(10, 11, 12), 10),
+            Sphere(0, 0, 0, 0),
+            Sphere(0, 0, 0, 1),
+            Sphere(1, 1, 1, 0),
+            Sphere(10, 11, 12, 10),
         ]
         expecteds = [0, 4.18879, 0, 4188.7902]
         for (case, expect) in zip(cases, expecteds):
@@ -51,10 +59,10 @@ class SphereOriginalTest(unittest.TestCase):
 
     def test_distance_between_centres_various_spheres_returns_correct_distance(self):
         cases = [
-            (Sphere(Point3D(0, 0, 0), 1), Sphere(Point3D(0, 0, 0), 1)),
-            (Sphere(Point3D(0, 0, 0), 1), Sphere(Point3D(1, 1, 1), 1)),
-            (Sphere(Point3D(1, 1, 1), 1), Sphere(Point3D(1, 1, 1), 10)),
-            (Sphere(Point3D(-1, -1, -1), 1), Sphere(Point3D(1, 1, 1), 10)),
+            (Sphere(0, 0, 0, 1), Sphere(Point3D(0, 0, 0), 1)),
+            (Sphere(0, 0, 0, 1), Sphere(Point3D(1, 1, 1), 1)),
+            (Sphere(1, 1, 1, 1), Sphere(Point3D(1, 1, 1), 10)),
+            (Sphere(-1, -1, -1, 1), Sphere(Point3D(1, 1, 1), 10)),
         ]
         expecteds = [0, 1.732051, 0, 3.464102]
         for (case, expect) in zip(cases, expecteds):
@@ -63,10 +71,10 @@ class SphereOriginalTest(unittest.TestCase):
 
     def test_distance_between_edges_various_spheres_returns_correct_distance(self):
         cases = [
-            (Sphere(Point3D(0, 0, 0), 1), Sphere(Point3D(0, 0, 0), 1)),
-            (Sphere(Point3D(0, 0, 0), 1), Sphere(Point3D(1, 1, 1), 1)),
-            (Sphere(Point3D(0, 0, 0), 1), Sphere(Point3D(10, 10, 10), 1)),
-            (Sphere(Point3D(-1, -1, -1), 1), Sphere(Point3D(10, 10, 10), 10)),
+            (Sphere(0, 0, 0, 1), Sphere(Point3D(0, 0, 0), 1)),
+            (Sphere(0, 0, 0, 1), Sphere(Point3D(1, 1, 1), 1)),
+            (Sphere(0, 0, 0, 1), Sphere(Point3D(10, 10, 10), 1)),
+            (Sphere(-1, -1, -1, 1), Sphere(Point3D(10, 10, 10), 10)),
         ]
         expecteds = [-2, -0.267949, 15.320508, 8.052559]
         for (case, expect) in zip(cases, expecteds):
@@ -75,11 +83,11 @@ class SphereOriginalTest(unittest.TestCase):
 
     def test_overlaps_various_spheres_returns_correct_boolean(self):
         cases = [
-            (Sphere(Point3D(0, 0, 0), 1), Sphere(Point3D(0, 0, 0), 1)),
-            (Sphere(Point3D(0, 0, 0), 1), Sphere(Point3D(1, 1, 1), 1)),
-            (Sphere(Point3D(0, 0, 0), 1), Sphere(Point3D(10, 10, 10), 1)),
-            (Sphere(Point3D(-1, -1, -1), 10), Sphere(Point3D(10, 10, 10), 10)),
-            (Sphere(Point3D(-1, 1, 4), 5), Sphere(Point3D(-2, -3, -4), 4)),
+            (Sphere(0, 0, 0), 1, Sphere(Point3D(0, 0, 0), 1)),
+            (Sphere(0, 0, 0), 1, Sphere(Point3D(1, 1, 1), 1)),
+            (Sphere(0, 0, 0), 1, Sphere(Point3D(10, 10, 10), 1)),
+            (Sphere(-1, -1, -1, 10), Sphere(Point3D(10, 10, 10), 10)),
+            (Sphere(-1, 1, 4, 5), Sphere(Point3D(-2, -3, -4), 4)),
         ]
         expecteds = [True, True, False, True, True]
         for (case, expect) in zip(cases, expecteds):
@@ -87,19 +95,19 @@ class SphereOriginalTest(unittest.TestCase):
                 self.assertEqual(expect, case[0].overlaps(case[1]))
 
     def test_equals_on_equal_spheres_returns_true(self):
-        sphere_a = Sphere(Point3D(1, 2, 3), 1)
-        sphere_b = Sphere(Point3D(1, 2, 3), 1)
+        sphere_a = Sphere(1, 2, 3, 1)
+        sphere_b = Sphere(1, 2, 3, 1)
         self.assertTrue(sphere_a == sphere_b)
 
     def test_equals_on_not_equal_spheres_returns_false(self):
-        sphere_a = Sphere(Point3D(1, 2, 3), 1)
-        sphere_b = Sphere(Point3D(1, 2, 3), 2)
+        sphere_a = Sphere(1, 2, 3, 1)
+        sphere_b = Sphere(1, 2, 3, 2)
         self.assertFalse(sphere_a == sphere_b)
 
     def test_equal_on_sphere_and_string_returns_false(self):
-        sphere = Sphere(Point3D(1, 2, 3), 4)
-        self.assertFalse("Sphere(Point3D(1, 2, 3), 4)" == sphere)
+        sphere = Sphere(1, 2, 3, 4)
+        self.assertFalse("Sphere(1, 2, 3, 4)" == sphere)
 
     def test_repr_arbitrary_sphere_returns_correct_string(self):
-        sphere = Sphere(Point3D(1, 2, 3), 4)
-        self.assertEqual("Sphere(Point3D(1, 2, 3), 4)", str(sphere))
+        sphere = Sphere(1, 2, 3, 4)
+        self.assertEqual("Sphere(, 2, 3, 4)", str(sphere))


### PR DESCRIPTION
### What

Made a class for the original `Sphere` class

### Why

This version will be the one we introduce the `Sphere` with before refactoring to have a `Point3D` class. I wanted a working version in the repo with unittests for completeness. 

### Testing

Yes, but the simple `assert` tests are defo lacking. That said, I am not worried as this will be pointed out in the topic, saying something like "uhh, feels incomplete, but it's getting mangled..." 
