### PR TITLE
🎓 Objects Methods Topic `Sphere` assert tests

### DIFF
--- a/site/topics/objects/methods.rst
+++ b/site/topics/objects/methods.rst
@@ -348,7 +348,7 @@ Testing
 -------
 
 * Below is a collection of ``assert`` tests for the ``Sphere`` class
-* Though, you may feel that at this stage it's getting harder to get a feel for how complete your tests are 
+* Though, you may feel that at this stage it's getting harder to get a feel for how complete your tests are
 
 .. code-block:: python
     :linenos:


### PR DESCRIPTION
### Related Issues or PRs

Related to #318 

### What

Add the simple `assert` tests for the `Sphere` class. Since `unittest` will be motivated harder in the following topic, I am trying not to poop on the assert tests too hard here, but it is noted that they are getting harder to manage. 
