### PR TITLE
🎓 Unittest start `subTest` examples

### DIFF
--- a/site/topics/testing/unittest.rst
+++ b/site/topics/testing/unittest.rst
@@ -224,8 +224,7 @@ Subtests
 * In the above example, each test input and expected output were stored in lists
 
     * I used two separate lists, but there is nothing stopping you from using one list of tuples
-
-* The variable names for the lists, ``cases`` and ``expecteds``, were arbitrary and by no means required
+    * The variable names for the lists, ``cases`` and ``expecteds``, were arbitrary and by no means required
 
 * First notice the loop --- there is nothing particularly important for the ``subTest`` here, but the ``zip`` function has not been seen yet
 

--- a/site/topics/testing/unittest.rst
+++ b/site/topics/testing/unittest.rst
@@ -198,7 +198,35 @@ Subtests
 * Although there is nothing wrong with the above tests, we can instead, we can make use of ``subTest`` in this scenario
 
 
+.. code-block:: python
+    :linenos:
+    :emphasize-lines: 15, 16
 
+    import unittest
+
+    class SphereTest(unittest.TestCase):
+
+        # Other test methods not shown for brevity
+
+        def test_diameter_various_spheres_returns_correct_diameter(self):
+            cases = [
+                Sphere(Point3D(0, 0, 0), 0),
+                Sphere(Point3D(0, 0, 0), 1),
+                Sphere(Point3D(1, 1, 1), 0),
+                Sphere(Point3D(10, 11, 12), 10),
+            ]
+            expecteds = [0, 2, 0, 20]
+            for (case, expect) in zip(cases, expecteds):
+                with self.subTest(case=case, expect=expect):
+                    self.assertAlmostEqual(expect, case.diameter(), 5)
+
+
+* In the above example, each test input and expected output were stored in lists
+
+    * I used two separate lists, but there is nothing stopping you from using one list of tuples
+
+* The variable names for the lists, ``cases`` and ``expecteds``, were arbitrary and by no means required
+* Then, the test method loops over the cases independently with ``subTest``
 
 
 

--- a/site/topics/testing/unittest.rst
+++ b/site/topics/testing/unittest.rst
@@ -227,8 +227,44 @@ Subtests
 
 * The variable names for the lists, ``cases`` and ``expecteds``, were arbitrary and by no means required
 
+* First notice the loop --- there is nothing particularly important for the ``subTest`` here, but the ``zip`` function has not been seen yet
+
+    * This just provides an easy way to loop over data within two lists at the same time
+    * This whole portion could be re-written as follows
+
+        .. code-block:: python
+            :linenos:
+
+            ...
+            for i in range(len(cases)):
+                with self.subTest(case=cases[i], expect=expecteds[i]):
+                    ...
 
 
+* Next, notice ``with self.subTest(case=case, expect=expect)``
+* There is a lot going on here, and much of it we will leave as *important code we need*
+
+* What is important is the assignment of the arguments
+
+    * ``case=case, expect=expect``
+
+* Up until now we have always specified the names and number of parameters a function/method takes
+* However, Python actually provides a way to provide an arbitrary number of arbitrarily named arguments
+* What is important is the name of the parameter we choose in these parentheses as they will be how we refer to the values
+
+    * ``self.assertAlmostEqual(expect, case.diameter(), 5)``
+    * This whole portion could be re-written as follows
+
+        .. code-block:: python
+            :linenos:
+
+            ...
+            with self.subTest(abc=case, xyz=expect):
+                self.assertAlmostEqual(abc, xyz.diameter(), 5)
+
+
+* It is possible to do multiple tests within a single test by just using a loop without the use of ``subTest``
+* However, without ``subTest``, if one of the tests fail, execution of the rest of the tests would stop and I would not know which subtest failed
 
 
 Running Unit Tests

--- a/site/topics/testing/unittest.rst
+++ b/site/topics/testing/unittest.rst
@@ -152,6 +152,56 @@ Writing Unit Tests
 Subtests
 --------
 
+* Often we have functionality we would like to test on various cases
+* But it feels rather silly writing a whole new test for each case
+
+* Consider the ``diameter`` method
+* What cases should be tested?
+* We want to check our edge cases and general cases
+
+    * Test a ``Sphere`` at the origin that has zero ``radius``
+    * Test a ``Sphere`` at the origin with non-zero ``radius``
+
+* But we may want to confirm that the ``centre_point`` has no impact on the ``diameter`` of the ``Sphere``
+
+    * Test a ``Sphere`` that exists in an arbitrary location with zero ``radius``
+    * Test a ``Sphere`` that exists in an arbitrary location with non-zero ``radius``
+
+* To test all four example cases the same way as the above tests, we would need four separate tests that are nearly identical
+
+.. code-block:: python
+    :linenos:
+
+    import unittest
+
+    class SphereTest(unittest.TestCase):
+
+        # Other test methods not shown for brevity
+
+        def test_diameter_radius_zero_origin_returns_zero(self):
+            sphere = Sphere(Point3D(0, 0, 0), 0)
+            self.assertEqual(0, sphere.diameter())
+
+        def test_diameter_radius_one_origin_returns_two(self):
+            sphere = Sphere(Point3D(0, 0, 0), 1)
+            self.assertEqual(2, sphere.diameter())
+
+        def test_diameter_radius_zero_arbitrary_centre_returns_zero(self):
+            sphere = Sphere(Point3D(1, 1, 1), 0)
+            self.assertEqual(0, sphere.diameter())
+
+        def test_diameter_radius_ten_arbitrary_centre_returns_twenty(self):
+            sphere = Sphere(Point3D(10, 11, 12), 10)
+            self.assertEqual(20, sphere.diameter())
+
+
+* Although there is nothing wrong with the above tests, we can instead, we can make use of ``subTest`` in this scenario
+
+
+
+
+
+
 
 Running Unit Tests
 ==================

--- a/site/topics/testing/unittest.rst
+++ b/site/topics/testing/unittest.rst
@@ -226,7 +226,7 @@ Subtests
     * I used two separate lists, but there is nothing stopping you from using one list of tuples
 
 * The variable names for the lists, ``cases`` and ``expecteds``, were arbitrary and by no means required
-* Then, the test method loops over the cases independently with ``subTest``
+
 
 
 

--- a/site/topics/testing/unittest.rst
+++ b/site/topics/testing/unittest.rst
@@ -265,6 +265,9 @@ Subtests
 * It is possible to do multiple tests within a single test by just using a loop without the use of ``subTest``
 * However, without ``subTest``, if one of the tests fail, execution of the rest of the tests would stop and I would not know which subtest failed
 
+* Lastly, notice the use of ``self.assertAlmostEqual``
+* Almost equal is a nice way to manage floating point precision issues, and in the above example we specified the precision we care about --- ``5``
+
 
 Running Unit Tests
 ==================

--- a/site/topics/testing/unittest.rst
+++ b/site/topics/testing/unittest.rst
@@ -213,9 +213,9 @@ Subtests
                 Sphere(Point3D(0, 0, 0), 0),
                 Sphere(Point3D(0, 0, 0), 1),
                 Sphere(Point3D(1, 1, 1), 0),
-                Sphere(Point3D(10, 11, 12), 10),
+                Sphere(Point3D(10, 11, 12), 10.1),
             ]
-            expecteds = [0, 2, 0, 20]
+            expecteds = [0, 2, 0, 20.2]
             for (case, expect) in zip(cases, expecteds):
                 with self.subTest(case=case, expect=expect):
                     self.assertAlmostEqual(expect, case.diameter(), 5)

--- a/test/test_sphere.py
+++ b/test/test_sphere.py
@@ -18,9 +18,9 @@ class SphereTest(unittest.TestCase):
             Sphere(Point3D(0, 0, 0), 0),
             Sphere(Point3D(0, 0, 0), 1),
             Sphere(Point3D(1, 1, 1), 0),
-            Sphere(Point3D(10, 11, 12), 10),
+            Sphere(Point3D(10, 11, 12), 10.1),
         ]
-        expecteds = [0, 2, 0, 20]
+        expecteds = [0, 2, 0, 20.2]
         for (case, expect) in zip(cases, expecteds):
             with self.subTest(case=case, expect=expect):
                 self.assertAlmostEqual(expect, case.diameter(), 5)

--- a/test/test_sphere_original.py
+++ b/test/test_sphere_original.py
@@ -25,9 +25,9 @@ class SphereOriginalTest(unittest.TestCase):
             Sphere(0, 0, 0, 0),
             Sphere(0, 0, 0, 1),
             Sphere(1, 1, 1, 0),
-            Sphere(10, 11, 12, 10),
+            Sphere(10, 11, 12, 10.1),
         ]
-        expecteds = [0, 2, 0, 20]
+        expecteds = [0, 2, 0, 20.2]
         for (case, expect) in zip(cases, expecteds):
             with self.subTest(case=case, expect=expect):
                 self.assertAlmostEqual(expect, case.diameter(), 5)


### PR DESCRIPTION
### What

1. Start the `subTest` examples
2. Explain some of the nuance needed for `subTest` 
3. Update unittests to have a float in one of the cases

### Why

Points 1 and 2 should be clear. 
RE 3, this change was made since it used `self.assertAlmostEqual` because `diameter` should work on floats too. Could have changed the test to just be `self.assertEqual` and left the cases alone, but since the functionality is for floats really, I figured it made more sense to go the way I did. 

### Testing

:+1: Re-ran unit tests due to the `radius` change to `10.1` for one of the cases. 

### Additional Notes

Some specific points are emphasized below in comments. 