### PR TITLE
🎓 Course Class add `contains` method

### DIFF
--- a/src/course.py
+++ b/src/course.py
@@ -32,6 +32,17 @@ class Course:
                 return i
         return -1
 
+    def contains(self, student: Student) -> bool:
+        """
+        Checks if a given student exists within the Course.
+
+        :param student: The Student object to be checked if it exists within the Course
+        :type student: Student
+        :return: True if the Student exists, False otherwise
+        :rtype: bool
+        """
+        return -1 != self.find(student)
+
     def remove(self, student: Student):
         """
         Remove the first occurence of the specified student from the collection. If the student does not exist, raise

--- a/src/course.py
+++ b/src/course.py
@@ -52,11 +52,11 @@ class Course:
         :param student: The student to be removed
         :type student: Student
         """
-        index = self._find(student)
-        if index == -1:
+
+        if not self.contains(student):
             raise ValueError("No such student to remove")
         else:
-            self._students.pop(index)
+            self._students.pop(self._find(student))
 
     def __repr__(self) -> str:
         s = ""

--- a/src/course.py
+++ b/src/course.py
@@ -17,7 +17,7 @@ class Course:
     def add(self, student: Student):
         self._students.append(student)
 
-    def find(self, student: Student) -> int:
+    def _find(self, student: Student) -> int:
         """
         Returns the index of the first occurrence of a given Student if it exists. If it does not exist, return a
         sentinel value of -1.
@@ -41,7 +41,7 @@ class Course:
         :return: True if the Student exists, False otherwise
         :rtype: bool
         """
-        return -1 != self.find(student)
+        return -1 != self._find(student)
 
     def remove(self, student: Student):
         """
@@ -52,7 +52,7 @@ class Course:
         :param student: The student to be removed
         :type student: Student
         """
-        index = self.find(student)
+        index = self._find(student)
         if index == -1:
             raise ValueError("No such student to remove")
         else:

--- a/test/test_course.py
+++ b/test/test_course.py
@@ -48,6 +48,20 @@ class CourseTest(TestCase):
         student_there = Student("Bob", "Smith", 123456789)
         self.assertEqual(0, course.find(student_there))
 
+    def test_contains_singleton_student_does_not_exist_returns_false(self):
+        course = Course("CS101")
+        student = Student("Bob", "Smith", 123456789)
+        course.add(student)
+        student_not_there = Student("Not", "Bob", 987654321)
+        self.assertFalse(course.contains(student_not_there))
+
+    def test_contains_singleton_student_exists_returns_true(self):
+        course = Course("CS101")
+        student = Student("Bob", "Smith", 123456789)
+        course.add(student)
+        student_there = Student("Bob", "Smith", 123456789)
+        self.assertTrue(course.contains(student_there))
+
     def test_remove_singleton_student_does_not_exist_raises_value_error(self):
         course = Course("CS101")
         student = Student("Bob", "Smith", 123456789)
@@ -101,6 +115,31 @@ class CourseTest(TestCase):
         course.add(Student("Jane", "Doe", 987654321))
         student_there = Student("Jane", "Doe", 987654321)
         self.assertEqual(1, course.find(student_there))
+
+    def test_contains_many_students_student_does_not_exist_returns_false(self):
+        course = Course("CS101")
+        course.add(Student("Bob", "Smith", 123456789))
+        course.add(Student("Jane", "Doe", 987654321))
+        course.add(Student("Niles", "MacDonald", 192837465))
+        student_not_there = Student("Not", "There", 918273645)
+        self.assertFalse(course.contains(student_not_there))
+
+    def test_contains_many_students_student_exists_returns_true(self):
+        course = Course("CS101")
+        course.add(Student("Bob", "Smith", 123456789))
+        course.add(Student("Jane", "Doe", 987654321))
+        course.add(Student("Niles", "MacDonald", 192837465))
+        student_there = Student("Jane", "Doe", 987654321)
+        self.assertTrue(course.contains(student_there))
+
+    def test_contains_many_students_duplicate_students_returns_true(self):
+        course = Course("CS101")
+        course.add(Student("Bob", "Smith", 123456789))
+        course.add(Student("Jane", "Doe", 987654321))
+        course.add(Student("Niles", "MacDonald", 192837465))
+        course.add(Student("Jane", "Doe", 987654321))
+        student_there = Student("Jane", "Doe", 987654321)
+        self.assertTrue(course.contains(student_there))
 
     def test_remove_many_students_student_does_not_exist_raises_value_error(self):
         course = Course("CS101")

--- a/test/test_course.py
+++ b/test/test_course.py
@@ -16,7 +16,7 @@ class CourseTest(TestCase):
     def test_find_empty_course_returns_negative_1(self):
         course = Course("CS101")
         student = Student("Bob", "Smith", 123456789)
-        self.assertEqual(-1, course.find(student))
+        self.assertEqual(-1, course._find(student))
 
     def test_remove_empty_course_raises_value_error(self):
         course = Course("CS101")
@@ -39,14 +39,14 @@ class CourseTest(TestCase):
         student = Student("Bob", "Smith", 123456789)
         course.add(student)
         student_not_there = Student("Not", "Bob", 987654321)
-        self.assertEqual(-1, course.find(student_not_there))
+        self.assertEqual(-1, course._find(student_not_there))
 
     def test_find_singleton_student_exists_returns_correct_index(self):
         course = Course("CS101")
         student = Student("Bob", "Smith", 123456789)
         course.add(student)
         student_there = Student("Bob", "Smith", 123456789)
-        self.assertEqual(0, course.find(student_there))
+        self.assertEqual(0, course._find(student_there))
 
     def test_contains_singleton_student_does_not_exist_returns_false(self):
         course = Course("CS101")
@@ -75,7 +75,7 @@ class CourseTest(TestCase):
         student = Student("Bob", "Smith", 123456789)
         course.add(student)
         course.remove(student)
-        self.assertEqual(-1, course.find(student))
+        self.assertEqual(-1, course._find(student))
 
     def test_repr_singleton_returns_correct_string(self):
         course = Course("CS101")
@@ -97,7 +97,7 @@ class CourseTest(TestCase):
         course.add(Student("Jane", "Doe", 987654321))
         course.add(Student("Niles", "MacDonald", 192837465))
         student_not_there = Student("Not", "There", 918273645)
-        self.assertEqual(-1, course.find(student_not_there))
+        self.assertEqual(-1, course._find(student_not_there))
 
     def test_find_many_students_student_exists_returns_correct_index(self):
         course = Course("CS101")
@@ -105,7 +105,7 @@ class CourseTest(TestCase):
         course.add(Student("Jane", "Doe", 987654321))
         course.add(Student("Niles", "MacDonald", 192837465))
         student_there = Student("Jane", "Doe", 987654321)
-        self.assertEqual(1, course.find(student_there))
+        self.assertEqual(1, course._find(student_there))
 
     def test_find_many_students_duplicate_students_returns_first_occurrence_index(self):
         course = Course("CS101")
@@ -114,7 +114,7 @@ class CourseTest(TestCase):
         course.add(Student("Niles", "MacDonald", 192837465))
         course.add(Student("Jane", "Doe", 987654321))
         student_there = Student("Jane", "Doe", 987654321)
-        self.assertEqual(1, course.find(student_there))
+        self.assertEqual(1, course._find(student_there))
 
     def test_contains_many_students_student_does_not_exist_returns_false(self):
         course = Course("CS101")
@@ -157,7 +157,7 @@ class CourseTest(TestCase):
         course.add(Student("Niles", "MacDonald", 192837465))
         student_there = Student("Jane", "Doe", 987654321)
         course.remove(student_there)
-        self.assertEqual(-1, course.find(student_there))
+        self.assertEqual(-1, course._find(student_there))
 
     def test_remove_many_students_duplicate_students_removes_first_occurrence(self):
         course = Course("CS101")
@@ -167,7 +167,7 @@ class CourseTest(TestCase):
         course.add(Student("Jane", "Doe", 987654321))
         student_there = Student("Jane", "Doe", 987654321)
         course.remove(student_there)
-        self.assertEqual(2, course.find(student_there))
+        self.assertEqual(2, course._find(student_there))
 
     def test_repr_many_student_returns_correct_string(self):
         course = Course("CS101")


### PR DESCRIPTION
### What

Add a `contains` method for the class. Make find start with underscore. 

### Why

1. It felt like it could use one more, idk 
2. Make find "private", or whatever they call it in Python, since I go on a rant in the course content about not accessing the `_students` attribute directly, but then `find` made it seem like, "well, why would I want the index if I am not accessing it the list directly?
3. `_find` is now used as helper for two other methods

### Testing
:+1:

### Additional Notes
There is a magic method, `__contains__` that is more _pythonic_ and uses the `in` operator. I opted to just not do this as I want to avoid more magic methods at this stage. I also never used `in` this way so far in the course; `in` has only been used in loops. 