### PR TITLE
🆕 Syllabus --- Assignment Recoupment

### DIFF
--- a/site/outline/outline.rst
+++ b/site/outline/outline.rst
@@ -224,6 +224,10 @@ only assignments deemed eligible may be resubmitted. Only assignments that were 
 eligible. Students with missing code/functions/portions of the assignment will not be eligible. If the student has
 portions of code that demonstrate a lack of a sincere attempt, the assignment will not be eligible for recoupment.
 
+Further, it is the responsibility of the student to make clear to the marker what exactly has been updated and changed.
+If the marker is unable to quickly determine what fixes the student has made, the resubmission will not be considered
+for recoupment. This could be in the form of notes in the Moodle submission with corresponding comments within the code. 
+
 
 Tests
 =====

--- a/site/outline/outline.rst
+++ b/site/outline/outline.rst
@@ -216,7 +216,8 @@ Students will have **1 week** after their marked assignment is returned to incor
 resubmit their assignments for additional marking. All corrected mistakes can recoup 50% of the lost marks on that
 assignment. For example, if a student obtained 80/100 on the assignment after the regular submission, and the student
 correctly fixes errors that account for 12 of the 20 lost marks and resubmits for recoupment, the student will gain 6
-more marks for a total of 86/100 on the assignment. As always, no late submissions will be accepted.
+more marks for a total of 86/100 on the assignment. As always, no late submissions will be accepted and all work will be
+checked for plagiarism or cheating. 
 
 There are some conditions, however. The marker will inform the student if their assignment is eligible for recoupment;
 only assignments deemed eligible may be resubmitted. Only assignments that were completed and attempted in earnest are

--- a/site/outline/outline.rst
+++ b/site/outline/outline.rst
@@ -217,7 +217,7 @@ resubmit their assignments for additional marking. All corrected mistakes can re
 assignment. For example, if a student obtained 80/100 on the assignment after the regular submission, and the student
 correctly fixes errors that account for 12 of the 20 lost marks and resubmits for recoupment, the student will gain 6
 more marks for a total of 86/100 on the assignment. As always, no late submissions will be accepted and all work will be
-checked for plagiarism or cheating. 
+checked for plagiarism or cheating.
 
 There are some conditions, however. The marker will inform the student if their assignment is eligible for recoupment;
 only assignments deemed eligible may be resubmitted. Only assignments that were completed and attempted in earnest are

--- a/site/outline/outline.rst
+++ b/site/outline/outline.rst
@@ -167,8 +167,11 @@ Student Evaluation (Tentative Dates)
 +------------------------+------------+---------------------+
 
 
-Assignment Submission
-=====================
+Assignments
+===========
+
+Submission
+----------
 
 Instructions for the submission of assignments will be posted on the course website. It is each student's responsibility
 to read and follow the instructions. Failure to follow the submission instructions may result in the assignment
@@ -178,15 +181,15 @@ You will be required to submit each programming assignment electronically. Detai
 descriptions. We reserve the right to use similarity detection software to detect possible cheating cases.
 
 
-Assignment Due Dates
-====================
+Due Dates
+---------
 
 The date and exact time assignments are due will be given in the assignment specifications. No submissions will be taken
 after the due date; there are no late submissions. No extensions will be given for assignments.
 
 
-Assignment Marking
-==================
+Marking
+-------
 
 Assignments are marked by the Teaching Assistants, who follow marking schemes provided by instructors.
 
@@ -201,6 +204,10 @@ It is each student's responsibility to keep up-to-date backups of assignment dis
 inadvertently erased files. Students must keep disk copies of all material submitted, as well as the actual graded
 assignment, to guard against the possibility of errors in recording marks. It is not safe to discard these materials
 until you are satisfied that your final mark for the course has been computed properly.
+
+
+Recoupment
+----------
 
 
 Tests

--- a/site/outline/outline.rst
+++ b/site/outline/outline.rst
@@ -209,6 +209,20 @@ until you are satisfied that your final mark for the course has been computed pr
 Recoupment
 ----------
 
+Since mistakes are expected and lost marks are meant to provide feedback and not intended to be a penalty, students can
+redeem 50% of their lost marks via *assignment recoupment*.
+
+Students will have **1 week** after their marked assignment is returned to incorporate feedback, correct mistakes, and
+resubmit their assignments for additional marking. All corrected mistakes can recoup 50% of the lost marks on that
+assignment. For example, if a student obtained 80/100 on the assignment after the regular submission, and the student
+corrects 12 of the 20 lost marks and resubmits for recoupment, the student will gain 6 more marks for a total of 86/100
+on the assignment. As always, no late submissions will be accepted.
+
+There are some conditions, however. The marker will inform the student if their assignment is eligible for recoupment;
+only assignments deemed eligible may be resubmitted. Only assignments that were completed and attempted in earnest are
+eligible. Students with missing code/functions/portions of the assignment will not be eligible. If the student has
+portions of code that demonstrate a lack of a sincere attempt, the assignment will not be eligible for recoupment.
+
 
 Tests
 =====

--- a/site/outline/outline.rst
+++ b/site/outline/outline.rst
@@ -215,8 +215,8 @@ redeem 50% of their lost marks via *assignment recoupment*.
 Students will have **1 week** after their marked assignment is returned to incorporate feedback, correct mistakes, and
 resubmit their assignments for additional marking. All corrected mistakes can recoup 50% of the lost marks on that
 assignment. For example, if a student obtained 80/100 on the assignment after the regular submission, and the student
-corrects 12 of the 20 lost marks and resubmits for recoupment, the student will gain 6 more marks for a total of 86/100
-on the assignment. As always, no late submissions will be accepted.
+correctly fixes errors that account for 12 of the 20 lost marks and resubmits for recoupment, the student will gain 6
+more marks for a total of 86/100 on the assignment. As always, no late submissions will be accepted.
 
 There are some conditions, however. The marker will inform the student if their assignment is eligible for recoupment;
 only assignments deemed eligible may be resubmitted. Only assignments that were completed and attempted in earnest are


### PR DESCRIPTION
### What

Explain _assignment recoupment_. 

### Why

This is something I did back in like 2016/2017. The idea is, students can take their returned assignments, correct mistakes, and recoup 50% of the lost marks. 

Eg. 
- A student gets 80/100
- They correctly fix things that account for 15 of the 20 lost marks
- They get +7.5 on the assignment for a total of 87.5/100. 

Motivation:
(a) Students are expected to make mistakes and are an essential part of learning
(b) Marks are not intended to be a reward/penalty; marks are for feedback
(c) We want students to actually look at their assignment feedback and use it as a learning opportunity 
(d) Marks tend to be very bimodal, and struggling students stand to benefit the most from this idea
(e) Students that actually care are the ones that will do this
(f) The marker will be using unit tests, so they will have more hours to dedicate to this
(g) It worked well before

The reason for the limitations on eligibility is to prevent students from submitting nonsense and using this as a mechanism to hand in late work. Basically, students can't vomit on the page and expect to get feedback to resubmit. 


### Additional Notes

The potential for ambiguity in the explanation is ripe for abuse and complaints, but fortunately the times I did this in the past for much larger courses, it ended up not being a problem --- though, those were different times... I considered adding a grade cutoff for eligibility, like, only submissions that get above 60% can resubmit, but I can see that getting hairy. 

Overall the TA will err on the side of _being nice_ in terms of eligibility, but at the end of the day, the constraints are in the syllabus so there is something to fall back on. 