### PR TITLE
🎓 Syllabus --- Missed midterm and reweight final

### DIFF
--- a/site/outline/outline.rst
+++ b/site/outline/outline.rst
@@ -240,6 +240,14 @@ a reasonable person would deem as cheating is not permitted and will be investig
 Test format will be in person; however, if necessary, the format *may* be changed to online. Students will be informed
 of the change as soon as possible. 
 
+
+Missed Midterm
+--------------
+
+If a student is unable to write the midterm, the weight of their midterm will be added to the weight of the final exam;
+the final exam will be worth 50% of the student's final grade,
+
+
 Labs
 ====
 


### PR DESCRIPTION
### What

Note in the syllabus that, if the midterm is not written, the final exam will include the midterm's portion of the final mark. This would mean their final is worth 50%. 

### Why

- The university/department has no mechanism to properly administer makeup midterms
- Each makeup midterm is the responsibility of the professor to schedule and proctor
- With the general increase in accommodations needed, this eliminates the need to have make up midterms.  
- With the increase that will come in COVID accommodations, this will further eliminate any headache

### Additional Notes

Having done this multiple times in the past at UWO, it ends up working out pretty well. Some students opt to just not write as they have many other midterms and they are happy to have the reweighting anyways. There may be a small number of students that think this is a good idea for them when it is not, but those edge cases tend to be students that would have, unfortunately, performed poorly regardless. 



