### PR TITLE
:new: Lab1 --- Mention Colab instead of Interpreter 

### DIFF
--- a/site/labs/hello-world/hello-world.rst
+++ b/site/labs/hello-world/hello-world.rst
@@ -30,6 +30,7 @@ Pre Lab Exercises
 
 #. `Chapter 1 exercise(s) <http://openbookproject.net/thinkcs/python/english3e/way_of_the_program.html#exercises>`_
 
+    * Although the exercises mention "the interpreter", you are to simply use Google Colab
     * 2
     * 4
 


### PR DESCRIPTION
### What

The pre-lab exercises talk about "the interpreter", and since this is the first actual thing they have to do on their own, I mention that they are using colab, and ignore "the interpreter".

### Why

Could totally cause confusion. 