### PR TITLE
:mortar_board: Index --- Add Math, Stats, and CS Society tutorial time

### DIFF
--- a/site/index.rst
+++ b/site/index.rst
@@ -97,7 +97,7 @@ MSCS Tutorial Nights
 
 The Math, Stats, and CS Society now has a time and location for our free tutorial sessions. 
 
-   * TBD
+* Mondays, starting at 5:15pm, MULH 4024
 
 
 .. toctree::


### PR DESCRIPTION
### What

Add the math, stats, and CS student society tutorial night to the index pafe. 

### Why

It's free extra help. 

### Where

Right on the home page. 

### Additional Notes

I assume there is no specified end time?