### PR TITLE
:lipstick: Index --- Move Booleans topic before Testing topic :microscope:

### DIFF
--- a/site/index.rst
+++ b/site/index.rst
@@ -110,8 +110,8 @@ The Math, Stats, and CS Society now has a time and location for our free tutoria
     topics/statements/statements
     topics/input/input
     topics/functions/functions
-    topics/testing/testing
     topics/booleans/booleans
+    topics/testing/testing
     topics/if-else/if-else
     topics/car-rental/car-rental
     topics/loops/loops


### PR DESCRIPTION
### What

Move the Booleans topic to be before the testing topic. 

### Why

We make use of the boolean operators in the testing topic, so it would be nice to talk about them before they need to use them. 

### How

Just changed the order of the topics in the index. 

### Additional Notes

Urgent because these topics are happening today. 