### PR TITLE
:telescope:  Testing Topic --- Change C -> F floating point test 

### DIFF
--- a/site/topics/testing/testing.rst
+++ b/site/topics/testing/testing.rst
@@ -186,8 +186,8 @@ Celsius to Fahrenheit Example Tests
     assert -40 == celsius_to_fahrenheit(-40)
     assert 23 == celsius_to_fahrenheit(-5)
     assert 86 == celsius_to_fahrenheit(30)
-    assert 89.6 == celsius_to_fahrenheit(32)
     # To address precision issues, we can look for a sufficiently small difference between the expected and actual
+    assert 0.001 >  abs(celsius_to_fahrenheit(32) - 89.6)
     assert 0.001 > abs(celsius_to_fahrenheit(37.7777) - 100)
 
 

--- a/src/functions_topic.py
+++ b/src/functions_topic.py
@@ -17,7 +17,7 @@ assert -40 == celsius_to_fahrenheit(-40)
 assert 23 == celsius_to_fahrenheit(-5)
 assert 86 == celsius_to_fahrenheit(30)
 # To address precision issues, we can look for a sufficiently small difference between the expected and actual
-assert 0.001 >  abs(celsius_to_fahrenheit(32) - 89.6)
+assert 0.001 > abs(celsius_to_fahrenheit(32) - 89.6)
 assert 0.001 > abs(celsius_to_fahrenheit(37.7777) - 100)
 
 

--- a/src/functions_topic.py
+++ b/src/functions_topic.py
@@ -16,8 +16,8 @@ assert 32 == celsius_to_fahrenheit(0)
 assert -40 == celsius_to_fahrenheit(-40)
 assert 23 == celsius_to_fahrenheit(-5)
 assert 86 == celsius_to_fahrenheit(30)
-assert 89.6 == celsius_to_fahrenheit(32)
 # To address precision issues, we can look for a sufficiently small difference between the expected and actual
+assert 0.001 >  abs(celsius_to_fahrenheit(32) - 89.6)
 assert 0.001 > abs(celsius_to_fahrenheit(37.7777) - 100)
 
 


### PR DESCRIPTION
### What

Change the one assert test with floating point result to use the absolute difference test

### Why

Although the particular test is fine the way it is, since I just went on about avoiding comparing floats directly with `==`, and I do not compare with `==` in the subsequent test with floats, it only makes sense for consistency. 

### Testing

:+1: 