### PR TITLE
:new: Labs --- Include testing requirement for pre-lab exercises

### DIFF
--- a/site/labs/conditionals/conditionals.rst
+++ b/site/labs/conditionals/conditionals.rst
@@ -34,6 +34,8 @@ Pre Lab Exercises
     * 10
     * 11
 
+#. Write assertion tests for each of your functions above
+
 
 Before Kattis
 =============

--- a/site/labs/linear-search/linear-search.rst
+++ b/site/labs/linear-search/linear-search.rst
@@ -32,11 +32,13 @@ Pre Lab Exercises
 
     * 3
     * 4
-    * 9
-    * 10
-    * 11
-    * 12
-    * 13
+    * 9 (use ``assert`` to test instead of their ``test`` function)
+    * 10 (use ``assert`` to test instead of their ``test`` function)
+    * 11 (use ``assert`` to test instead of their ``test`` function)
+    * 12 (use ``assert`` to test instead of their ``test`` function)
+    * 13 (use ``assert`` to test instead of their ``test`` function)
+
+#. Write assertion tests for each of your functions above
 
 
 Before Kattis

--- a/site/labs/lists/1d-lists.rst
+++ b/site/labs/lists/1d-lists.rst
@@ -38,6 +38,8 @@ Pre Lab Exercises
     * 5
     * 6
 
+#. Write assertion tests for each of your functions above
+
 
 Before Kattis
 =============

--- a/site/labs/lists/2d-lists.rst
+++ b/site/labs/lists/2d-lists.rst
@@ -38,6 +38,8 @@ Pre Lab Exercises
     * 7
     * 8
 
+#. Write assertion tests for each of your functions above
+
 
 Before Kattis
 =============

--- a/site/labs/lists/references.rst
+++ b/site/labs/lists/references.rst
@@ -36,6 +36,8 @@ Pre Lab Exercises
 
     * 2
 
+#. Write assertion tests for each of your functions above
+
 
 Before Kattis
 =============

--- a/site/labs/loops/loops.rst
+++ b/site/labs/loops/loops.rst
@@ -34,6 +34,8 @@ Pre Lab Exercises
     * 14 (use ``assert`` to test instead of their ``test`` function)
     * 15 (use ``assert`` to test instead of their ``test`` function)
 
+#. Write assertion tests for each of your functions above
+
 
 Before Kattis
 =============

--- a/site/labs/objects/data-structures.rst
+++ b/site/labs/objects/data-structures.rst
@@ -33,6 +33,8 @@ Pre Lab Exercises
 
     * 6
 
+#. Write assertion tests for each of your functions above
+
 
 Before Kattis
 =============


### PR DESCRIPTION
### What

Add a requirement to do assertion tests for the pre-lab exercises from the conditionals lab forward (where applicable). 

### Why

1. Testing is good
2. Seems like students are cheating on the pre-lab exercises a lot by finding solutions online. Checking if they did the tests will be easy, and if they do cheat, but at least did the tests, then we can concede that they spent time thinking about solutions. 

### Where

All labs where applicable from the 3rd lab forward. 3rd lab forward since that will be roughly where they see the assertion tests. 

### Additional Notes

When going through the pre-lab exercises, some were pretty rough. May need to adjust going forward --- we'll see. 