### PR TITLE
:bomb: Conditionals Lab --- Remove Q2 from prelab

### DIFF
--- a/site/labs/conditionals/conditionals.rst
+++ b/site/labs/conditionals/conditionals.rst
@@ -30,7 +30,6 @@ Pre Lab Exercises
 #. `Chapter 5 exercise(s) <http://openbookproject.net/thinkcs/python/english3e/conditionals.html#exercises>`_
 
     * 1
-    * 2 (do not forget about ``%``)
     * 10
     * 11
 


### PR DESCRIPTION
### What

Remove Q2 from the pre-lab exercises. 

### Why

1. It's mean at this point
2. Chances are we wont have hit `%`, which it will need
3. It doesn't require any conditionals (though, it should call Q1, which does), which is the point of the lab. 

### Additional Notes

The only value the question has is the fact that it should use the function from Q1, but the challenge doesn't justify it; pre-lab are supposed to be easy and the students are struggling with it. 

There is a similar argument to be made about Q10, and how it doesn't use conditionals, but it's simple enough, and it will help them remember triangle stuff which is needed for Q11. 