### PR TITLE
:bug: Lab 5 --- Fix math range typesetting :microscope: 

### DIFF
--- a/site/labs/loops/loops.rst
+++ b/site/labs/loops/loops.rst
@@ -40,12 +40,12 @@ Pre Lab Exercises
 Before Kattis
 =============
 
-#. Write a function ``count_to_n_while(n: int):`` to print out each number from :math:`0 -- (n - 1)`
+#. Write a function ``count_to_n_while(n: int):`` to print out each number from :math:`0` -- :math:`(n - 1)`
 
     * This function must use a ``while`` loop
     * This function will not return anything
 
-#. Write a function ``count_to_n_for(n: int):`` to print out each number from :math:`0 -- (n - 1)`
+#. Write a function ``count_to_n_for(n: int):`` to print out each number from :math:`0` -- :math:`(n - 1)`
 
     * This function must use a ``for`` loop
     * This function will not return anything


### PR DESCRIPTION
### What

Fix the math range typesetting. 

### Why

It was wrong, and made it confusing since the two dashes looked like it was a range from 0 to a negative number. 

### How

Just made the range `--` not in math mode. 