### PR TITLE
:bug: Lab 5 (loops) --- Mention no assert test for prelab exercise

### DIFF
--- a/site/labs/loops/loops.rst
+++ b/site/labs/loops/loops.rst
@@ -29,11 +29,11 @@ Pre Lab Exercises
 
 #. `Chapter 7 exercise(s) <http://openbookproject.net/thinkcs/python/english3e/iteration.html#exercises>`_
 
-    * 9 `What is a "triangle number"? <https://en.wikipedia.org/wiki/Triangular_number>`_
+    * 9 `What is a "triangle number"? <https://en.wikipedia.org/wiki/Triangular_number>`_ (no ``assert`` test for this)
     * 14 (use ``assert`` to test instead of their ``test`` function)
     * 15 (use ``assert`` to test instead of their ``test`` function) --- not required, but recommended
 
-#. Write assertion tests for each of your functions above
+#. Write assertion tests for each of your functions above, except for exercise 9, since it requires ``print``
 
 
 Before Kattis


### PR DESCRIPTION
### What

Mention that they should not bother with an `assert` test for the question on triangle numbers. 

### Why

The function for the question makes use of a bunch of prints.