### PR TITLE
:bomb: Linear Search Lab --- Remove prelab q4 

### DIFF
--- a/site/labs/linear-search/linear-search.rst
+++ b/site/labs/linear-search/linear-search.rst
@@ -31,7 +31,6 @@ Pre Lab Exercises
 #. `Chapter 8 exercise(s) <http://openbookproject.net/thinkcs/python/english3e/strings.html#exercises>`_
 
     * 3
-    * 4
     * 9 (use ``assert`` to test instead of their ``test`` function) --- not required, but recommended
     * 10 (use ``assert`` to test instead of their ``test`` function) --- not required, but recommended
     * 11 (use ``assert`` to test instead of their ``test`` function) --- not required, but recommended


### PR DESCRIPTION
### What

Remove the prelab question 4

### Why

It's a bad question. It makes no sense. it's confusing. There are problems. Does the `find` method have an optional third param? (it doesn't) We add the third param to keep looking for letters, even though the function `count_letters` is doing that already? wut?

### Additional Notes

Not this year, but will need to look at the "not required" questions from the pre-lab to add some back in to be required. 
