### PR TITLE
:bug: 2D List Lab 8 --- Indent images to fix numbering

### DIFF
--- a/site/labs/lists/2d-lists.rst
+++ b/site/labs/lists/2d-lists.rst
@@ -68,7 +68,7 @@ Given the following code:
                 ['g', 'h', 'i']]
 
 
-#. Write a function ``print_row(matrix, row: int):``
+1. Write a function ``print_row(matrix, row: int):``
 
     * ``matrix`` is a list of lists (2D list)
     * ``row`` is the specified row to print
@@ -80,7 +80,7 @@ Given the following code:
 .. image:: matRow.png
 
 
-#. Write a function ``print_column(matrix, column: int):``
+2. Write a function ``print_column(matrix, column: int):``
 
     * ``matrix`` is a list of lists (2D list)
     * ``column`` is the specified column to print
@@ -92,7 +92,7 @@ Given the following code:
 .. image:: matCol.png
 
 
-#. Write a function ``print_down_right(matrix):``
+3. Write a function ``print_down_right(matrix):``
 
     * ``matrix`` is a list of lists (2D list)
     * The function will print out the values of the matrix diagonal starting in the top left moving down to the right
@@ -103,7 +103,7 @@ Given the following code:
 .. image:: matDiag3.png
 
 
-#. Write a function ``print_up_right(matrix):``
+4. Write a function ``print_up_right(matrix):``
 
     * ``matrix`` is a list of lists (2D list)
     * The function will print out the values of the matrix diagonal starting in the bottom left moving up to the right
@@ -115,7 +115,7 @@ Given the following code:
 .. image:: matDiag4.png
 
 
-#. Write a function ``print_down_left(matrix):``
+5. Write a function ``print_down_left(matrix):``
 
     * ``matrix`` is a list of lists (2D list)
     * The function will print out the values of the matrix diagonal starting in the top right moving down to the left
@@ -126,7 +126,7 @@ Given the following code:
 .. image:: matDiag5.png
 
 
-#. Write a function ``print_up_left(matrix):``
+6. Write a function ``print_up_left(matrix):``
 
     * ``matrix`` is a list of lists (2D list)
     * The function will print out the values of the matrix diagonal starting in the bottom right moving up to the left
@@ -137,7 +137,7 @@ Given the following code:
 .. image:: matDiag6.png
 
 
-#. To verify that your functions work on arbitrary sized 2D lists, what happens if you run your functions with the following matrix?
+7. To verify that your functions work on arbitrary sized 2D lists, what happens if you run your functions with the following matrix?
 
         * Ensure each function works as expected
         * If the functions are only printing out three values, there is something wrong

--- a/site/labs/lists/2d-lists.rst
+++ b/site/labs/lists/2d-lists.rst
@@ -77,7 +77,7 @@ Given the following code:
     * The function will not return anything
     * Verify correctness by running the function on multiple 2D lists
 
-.. image:: matRow.png
+    .. image:: matRow.png
 
 
 #. Write a function ``print_column(matrix, column: int):``
@@ -89,7 +89,7 @@ Given the following code:
     * The function will not return anything
     * Verify correctness by running the function on multiple 2D lists
 
-.. image:: matCol.png
+    .. image:: matCol.png
 
 
 #. Write a function ``print_down_right(matrix):``
@@ -100,7 +100,7 @@ Given the following code:
     * The function will not return anything
     * Verify correctness by running the function on multiple 2D lists
 
-.. image:: matDiag3.png
+    .. image:: matDiag3.png
 
 
 #. Write a function ``print_up_right(matrix):``
@@ -112,7 +112,7 @@ Given the following code:
     * Verify correctness by running the function on multiple 2D lists
 
 
-.. image:: matDiag4.png
+    .. image:: matDiag4.png
 
 
 #. Write a function ``print_down_left(matrix):``
@@ -123,7 +123,7 @@ Given the following code:
     * The function will not return anything
     * Verify correctness by running the function on multiple 2D lists
 
-.. image:: matDiag5.png
+    .. image:: matDiag5.png
 
 
 #. Write a function ``print_up_left(matrix):``
@@ -134,7 +134,7 @@ Given the following code:
     * The function will not return anything
     * Verify correctness by running the function on multiple 2D lists
 
-.. image:: matDiag6.png
+    .. image:: matDiag6.png
 
 
 #. To verify that your functions work on arbitrary sized 2D lists, what happens if you run your functions with the following matrix?

--- a/site/labs/lists/2d-lists.rst
+++ b/site/labs/lists/2d-lists.rst
@@ -68,7 +68,7 @@ Given the following code:
                 ['g', 'h', 'i']]
 
 
-1. Write a function ``print_row(matrix, row: int):``
+#. Write a function ``print_row(matrix, row: int):``
 
     * ``matrix`` is a list of lists (2D list)
     * ``row`` is the specified row to print
@@ -80,7 +80,7 @@ Given the following code:
 .. image:: matRow.png
 
 
-2. Write a function ``print_column(matrix, column: int):``
+#. Write a function ``print_column(matrix, column: int):``
 
     * ``matrix`` is a list of lists (2D list)
     * ``column`` is the specified column to print
@@ -92,7 +92,7 @@ Given the following code:
 .. image:: matCol.png
 
 
-3. Write a function ``print_down_right(matrix):``
+#. Write a function ``print_down_right(matrix):``
 
     * ``matrix`` is a list of lists (2D list)
     * The function will print out the values of the matrix diagonal starting in the top left moving down to the right
@@ -103,7 +103,7 @@ Given the following code:
 .. image:: matDiag3.png
 
 
-4. Write a function ``print_up_right(matrix):``
+#. Write a function ``print_up_right(matrix):``
 
     * ``matrix`` is a list of lists (2D list)
     * The function will print out the values of the matrix diagonal starting in the bottom left moving up to the right
@@ -115,7 +115,7 @@ Given the following code:
 .. image:: matDiag4.png
 
 
-5. Write a function ``print_down_left(matrix):``
+#. Write a function ``print_down_left(matrix):``
 
     * ``matrix`` is a list of lists (2D list)
     * The function will print out the values of the matrix diagonal starting in the top right moving down to the left
@@ -126,7 +126,7 @@ Given the following code:
 .. image:: matDiag5.png
 
 
-6. Write a function ``print_up_left(matrix):``
+#. Write a function ``print_up_left(matrix):``
 
     * ``matrix`` is a list of lists (2D list)
     * The function will print out the values of the matrix diagonal starting in the bottom right moving up to the left
@@ -137,7 +137,7 @@ Given the following code:
 .. image:: matDiag6.png
 
 
-7. To verify that your functions work on arbitrary sized 2D lists, what happens if you run your functions with the following matrix?
+#. To verify that your functions work on arbitrary sized 2D lists, what happens if you run your functions with the following matrix?
 
         * Ensure each function works as expected
         * If the functions are only printing out three values, there is something wrong


### PR DESCRIPTION
### What

changed the before kattis question numbers so they are in correct order by indenting images. 

### Why

idk, felt like it lol

### Where

lab 8-2D lists

### How

on here, idk if i did it right




