### PR TITLE
:new: Objects I & II --- add import of math before class name :microscope: 

### DIFF
--- a/site/topics/objects/introduction.rst
+++ b/site/topics/objects/introduction.rst
@@ -229,6 +229,9 @@ Functionality and Methods
 .. code-block:: python
     :linenos:
 
+    import math
+
+
     class Circle:
 
         # init and/or other methods not shown for brevity

--- a/site/topics/objects/methods.rst
+++ b/site/topics/objects/methods.rst
@@ -93,6 +93,9 @@ Methods
 .. code-block:: python
     :linenos:
 
+    import math
+
+
     class Sphere:
 
         # init and/or other methods not shown for brevity
@@ -119,6 +122,9 @@ Methods
 
 .. code-block:: python
     :linenos:
+
+    import math
+
 
     class Sphere:
 
@@ -186,6 +192,9 @@ Methods
 .. code-block:: python
     :linenos:
 
+    import math
+
+
     class Sphere:
 
         # init and/or other methods not shown for brevity
@@ -210,6 +219,9 @@ Methods
 
 .. code-block:: python
     :linenos:
+
+    import math
+
 
     class Sphere:
 
@@ -270,6 +282,9 @@ Magic Methods
 .. code-block:: python
     :linenos:
 
+    import math
+
+
     class Sphere:
 
         # init and/or other methods not shown for brevity
@@ -311,6 +326,9 @@ Magic Methods
     :linenos:
     :emphasize-lines: 5
 
+    import math
+
+
     class Sphere:
 
         # init and/or other methods not shown for brevity
@@ -328,6 +346,9 @@ Magic Methods
 
     .. code-block:: python
         :linenos:
+
+        import math
+
 
         class Circle:
 
@@ -384,6 +405,9 @@ Magic Methods
 .. code-block:: python
     :linenos:
 
+    import math
+
+
     class Sphere:
 
         # init and/or other methods not shown for brevity
@@ -400,6 +424,9 @@ Magic Methods
 
     .. code-block:: python
         :linenos:
+
+        import math
+
 
         class Circle:
 


### PR DESCRIPTION
### What

Add the math import before all the class defs

### Why

It's already led to some confusion. This should address it. 
