### PR TITLE
:telescope:  Objects III --- Add more imports to math

### DIFF
--- a/site/topics/objects/interacting-objects.rst
+++ b/site/topics/objects/interacting-objects.rst
@@ -75,6 +75,9 @@ Methods
 .. code-block:: python
     :linenos:
 
+    import math
+
+
     class Point3D:
 
         # init and/or other methods not shown for brevity
@@ -98,6 +101,9 @@ Methods
 
 .. code-block:: python
     :linenos:
+
+    import math
+
 
     class Point3D:
 
@@ -213,6 +219,9 @@ Methods
 .. code-block:: python
     :linenos:
 
+    import math
+
+
     class Sphere:
 
         # init and/or other methods not shown for brevity
@@ -231,6 +240,9 @@ Methods
 
 .. code-block:: python
     :linenos:
+
+    import math
+
 
     class Sphere:
 
@@ -254,6 +266,9 @@ Methods
 
 .. code-block:: python
     :linenos:
+
+    import math
+
 
     class Sphere:
 
@@ -294,6 +309,9 @@ Methods
 .. code-block:: python
     :linenos:
 
+    import math
+
+
     class Sphere:
 
         # init and/or other methods not shown for brevity
@@ -310,6 +328,9 @@ Methods
 
 .. code-block:: python
     :linenos:
+
+    import math
+
 
     class Sphere:
 


### PR DESCRIPTION
### Related Issues or PRs

Just like #500 

### What

Add `import math` before each example of the class code. 

### Why

It had confused them before, and for the sake of consistency, here too.
