### PR TITLE
:bug: :telescope: Unittest topic --- Update repr test

### DIFF
--- a/site/topics/testing/unittest.rst
+++ b/site/topics/testing/unittest.rst
@@ -133,7 +133,6 @@ Writing Unit Tests
             self.assertEqual("Sphere(centre_point=Point3D(x=1, y=2, z=3), radius=4)", str(sphere))
 
 
-
 * Above are additional tests for the magic methods ``__eq__`` and ``__repr__``
 * For two of the ``__eq__`` methods, you will see the setup is a little more involved as we need two ``Sphere`` objects for the test
 * You will also notice the use of ``assertNotEqual``, which is just another type of test

--- a/site/topics/testing/unittest.rst
+++ b/site/topics/testing/unittest.rst
@@ -130,7 +130,8 @@ Writing Unit Tests
 
         def test_repr_arbitrary_sphere_returns_correct_string(self):
             sphere = Sphere(Point3D(1, 2, 3), 4)
-            self.assertEqual("Sphere(Point3D(1, 2, 3), 4)", str(sphere))
+            self.assertEqual("Sphere(centre_point=Point3D(x=1, y=2, z=3), radius=4)", str(sphere))
+
 
 
 * Above are additional tests for the magic methods ``__eq__`` and ``__repr__``

--- a/site/topics/testing/unittest.rst
+++ b/site/topics/testing/unittest.rst
@@ -126,7 +126,7 @@ Writing Unit Tests
 
         def test_equal_on_sphere_and_string_returns_false(self):
             sphere = Sphere(Point3D(1, 2, 3), 4)
-            self.assertNotEqual("Sphere(Point3D(1, 2, 3), 4)", sphere)
+            self.assertNotEqual("Sphere(centre_point=Point3D(x=1, y=2, z=3), radius=4)", sphere)
 
         def test_repr_arbitrary_sphere_returns_correct_string(self):
             sphere = Sphere(Point3D(1, 2, 3), 4)

--- a/test/test_sphere.py
+++ b/test/test_sphere.py
@@ -98,7 +98,7 @@ class SphereTest(unittest.TestCase):
 
     def test_equal_on_sphere_and_string_returns_false(self):
         sphere = Sphere(Point3D(1, 2, 3), 4)
-        self.assertNotEqual("Sphere(x=1, y=2, z=3, radius=4)", sphere)
+        self.assertNotEqual("Sphere(centre_point=Point3D(x=1, y=2, z=3), radius=4)", sphere)
 
     def test_repr_arbitrary_sphere_returns_correct_string(self):
         sphere = Sphere(Point3D(1, 2, 3), 4)


### PR DESCRIPTION
### What

Change the repr test for the `Sphere` class in the topic notes

### Why

It's wrong. I believe it _was_ this way before, but at some point got updated. 

### Additional Notes

There is a # to ref, but I didn't find it in 2s, so I give up. Too inconsequential to dig deeper. 