### PR TITLE
:lipstick: Objects Lab --- Reference unit test stuff & clean circle tests

### DIFF
--- a/site/labs/objects/objects.rst
+++ b/site/labs/objects/objects.rst
@@ -70,6 +70,12 @@ Before Kattis
     * Make instances of the class and write ``assert`` tests to verify correctness
 
 
+#. Create unittest classes for each of the above classes
+
+    * Write tests for each of the methods in each class
+    * Ensure all tests pass
+    * Run the tests with ``unittest.main(argv=[''], verbosity=2, exit=False)``
+
 Kattis Problems
 ===============
 


### PR DESCRIPTION
### What
1. Add link to unittest topic
2. Add download link to circle unittests
3. Remove the use of `setUp` in circle unit tests
4. remove dumb tests

### Why
1. Helpful
2. Helpful (were doing it already, so why not add link)
3. It threw them off
4. they were dumb

### Testing

:+1: