### PR TITLE
:bomb: Index --- Remove link to twitter :bird: 

### DIFF
--- a/site/index.rst
+++ b/site/index.rst
@@ -19,7 +19,6 @@ Dr. James Hughes (Section 11)
 
 * jhughes at stfx.ca
 * Annex 20B
-* `@Modsurski <https://twitter.com/Modsurski>`_
 * `YouTube <https://www.youtube.com/channel/UCIruexBZJaawh_9WF_vjTPg>`_
 
 


### PR DESCRIPTION
### What

Remove link to twitter. 

### Why

I don't use it, and have not in a while. 

### Additional Notes

Nothing political, it's just dumb. 