### PR TITLE
 :lipstick:  Update css and create other admonition classes

### DIFF
--- a/site/_static/css/custom.css
+++ b/site/_static/css/custom.css
@@ -77,10 +77,10 @@ div.highlight div.mac-header span.dot {
   width: 14px;
   height: 14px;
   border-radius: 50%;
-  background: rgba(0,0,0,0.1);
+/*   background: rgba(0,0,0,0.1); */
   margin: 0 4px 0 0;
 }
-div.highlight:hover div.mac-header span.dot.red {
+/* div.highlight:hover div.mac-header span.dot.red {
   background: rgb(255,86,80);
 }
 div.highlight:hover div.mac-header span.dot.yellow {
@@ -88,7 +88,7 @@ div.highlight:hover div.mac-header span.dot.yellow {
 }
 div.highlight:hover div.mac-header span.dot.green {
   background: rgb(41,193,68);
-}
+} */
 div.highlight div.mac-header span.copy {
   position: absolute;
   top: 0;

--- a/site/_static/css/custom.css
+++ b/site/_static/css/custom.css
@@ -1,51 +1,109 @@
-/*
-    Title and background colors for the class activity.
-*/
-.rst-content .activity .admonition-title {
-    background: #5594ca
-}
- 
-.rst-content .activity {
-    background: #c5dfff
+/* ===== Admonition ===== */
+
+.rst-content .admonition {
+    border-radius: 6px;
 }
 
-/*
-    Title and background colors for the class note.
-    By default notes already has a template.
-    Uncomment to modify it.
-*/
-/* .rst-content .note .admonition-title {
-    background: #5594ca
+.rst-content .admonition .admonition-title {
+    border-top-left-radius: 6px;
+    border-top-right-radius: 6px;
 }
- 
-.rst-content .note {
-    background: #c5dfff
-} */
 
-/*
-    Title and background colors for the class warning.
-    By default notes already has a template.
-    Uncomment to modify it.
-*/
-/* .rst-content .warning .admonition-title {
-    background: #5594ca
+.rst-content .admonition.note {
+    background: linear-gradient(to bottom right, rgba(59,124,221,0.3), rgba(30,124,221,0.15));
 }
- 
-.rst-content .warning {
-    background: #c5dfff
-} */
 
-/*
-    Title and background colors for the class important.
-    By default notes already has a template.
-    Uncomment to modify it.
-*/
-/* .rst-content .important .admonition-title {
-    background: #5594ca
+.rst-content .admonition.note .admonition-title {
+    background: linear-gradient(to bottom right, rgba(23,90,180,0.3), rgba(30,124,221,0.3));
 }
- 
-.rst-content .important {
-    background: #c5dfff
-} */
 
-/* Add new styles below */
+.rst-content .admonition.activity {
+    background: linear-gradient(to bottom right, rgba(255,185,47,0.3), rgba(255,142,38,0.15));
+}
+
+.rst-content .admonition.activity .admonition-title {
+    background: linear-gradient(to bottom right, rgba(243,113,33,0.3), rgba(255,142,38,0.3));
+}
+
+.rst-content .admonition.example {
+  background: linear-gradient(to bottom right, rgba(33, 138, 127, 0.3), rgba(33, 138, 127, 0.15));
+}
+
+.rst-content .admonition.example .admonition-title {
+  background: linear-gradient(to bottom right, rgba(17, 138, 126, 0.3), rgba(25, 136, 125, 0.3));
+}
+
+.rst-content .admonition.warning {
+  background: linear-gradient(to bottom right, rgba(255, 47, 75, 0.3), rgba(255, 47, 75, 0.15));
+}
+
+.rst-content .admonition.warning .admonition-title {
+  background: linear-gradient(to bottom right, rgba(247, 78, 100, 0.3), rgba(245, 101, 120, 0.3));
+}
+
+.rst-content .admonition.important {
+  background: linear-gradient(to bottom right, rgba(117, 92, 187, 0.3), rgba(117, 92, 187, 0.15));
+}
+
+.rst-content .admonition.important .admonition-title {
+  background: linear-gradient(to bottom right, rgba(98, 71, 170, 0.3), rgba(163, 146, 209, 0.3));
+}
+
+/* ===== Code ===== */
+
+.rst-content div[class^=highlight]{
+  border: none;
+}
+
+
+div.highlight{
+  border: none;
+  background: rgba(27,31,35,.05);
+  border-radius: 6px;
+}
+.rst-content {
+  overflow-wrap: break-word;
+}
+div.highlight {
+  background: linear-gradient(to bottom right, rgb(242,242,242), rgb(236,236,236));
+}
+div.highlight div.mac-header {
+  display: flex;
+  position: relative;
+  padding: 9px 0 9px 12px;
+  background: rgb(232,232,232);
+}
+div.highlight div.mac-header span.dot {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: rgba(0,0,0,0.1);
+  margin: 0 4px 0 0;
+}
+div.highlight:hover div.mac-header span.dot.red {
+  background: rgb(255,86,80);
+}
+div.highlight:hover div.mac-header span.dot.yellow {
+  background: rgb(255,181,60);
+}
+div.highlight:hover div.mac-header span.dot.green {
+  background: rgb(41,193,68);
+}
+div.highlight div.mac-header span.copy {
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: 6px 12px;
+  font-size: 18px;
+  cursor: pointer;
+  color: rgba(0,0,0,0.1);
+}
+div.highlight div.mac-header span.copy:hover {
+  color: rgba(0,0,0,0.5);
+}
+div.highlight div.mac-header span.copy:active {
+  color: rgb(30,124,221);
+}
+.rst-content code.xref {
+  padding: .2em .4em;
+}

--- a/site/_static/js/on_load.js
+++ b/site/_static/js/on_load.js
@@ -1,0 +1,19 @@
+$(document).ready(function() {
+    // Remove "Build with Sphinx" text in the footer:
+    var elem = $("footer div[role='contentinfo']").get(0);
+    while (elem.nextSibling)
+      elem.nextSibling.remove();
+  
+    // Code block header:
+    var $highlight = $("div.rst-content div.highlight");
+    $highlight.prepend("<div class='mac-header'><span class='dot red'></span><span class='dot yellow'></span><span class='dot green'></span><span class='copy fa fa-clipboard' title='Copy to clipboard'></span></div>");
+  
+    // Copy text in code blocks:
+    $highlight.find('span.copy').click(function() {
+      navigator.clipboard.writeText($(this).parent().parent().text().slice(0, -1));
+    });
+  
+
+
+  });
+

--- a/site/conf.py
+++ b/site/conf.py
@@ -127,6 +127,7 @@ html_static_path = ["_static"]
 # These paths are either relative to html_static_path
 # or fully qualified paths (eg. https://...)
 html_css_files = ["css/custom.css"]
+html_js_files = ["js/on_load.js"]
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.


### PR DESCRIPTION
 :lipstick: 

### Related Issues or PRs

Following #195

### What

Update the custom.css file with new admonition classes and colors.
Create a JS file to give a "mac" header to code-block and a clipboard button to copy the code.

### Why

Improve the color of the activities and other admonitions.

### Where

Everywhere.

### How

New CSS and JS files and modification of conf.py.

### Testing

![image](https://user-images.githubusercontent.com/75489434/212769999-c38aab3c-f007-4c9b-8bb7-8982aea0a584.png)


### Additional Notes

How to use the new admonition classes:

- Activity:

```
.. admonition:: Activity
   :class: activity
```
- Example:

```
.. admonition:: Example
   :class: example
```