### PR TITLE
💣 Remove Q7 from Pre-Lab

### DIFF
--- a/site/labs/testing/testing.rst
+++ b/site/labs/testing/testing.rst
@@ -22,7 +22,6 @@ Pre Lab Exercises
 
 #. `Chapter 4 exercise(s) <http://openbookproject.net/thinkcs/python/english3e/functions.html#exercises>`_
 
-    * 7 **but** write assertion tests for the function, include type hints, and write a docstring
     * 8 **but** write assertion tests for the function, include type hints, and write a docstring
 
 


### PR DESCRIPTION
### What

Remove Q7 from pre-lab

### Why

Takes away from the point of the lab
