### PR TITLE
:lipstick: :technologist:  Topic if else --- Use `a_number` in calculations :microscope: 

### DIFF
--- a/site/topics/if-else/if-else.rst
+++ b/site/topics/if-else/if-else.rst
@@ -42,7 +42,7 @@ Conditional Expressions
         """
         return_value = a_number
         if a_number > 0:
-            return_value = return_value / 2
+            return_value = a_number / 2
         return return_value
 
 

--- a/src/if_else_topic.py
+++ b/src/if_else_topic.py
@@ -9,7 +9,7 @@ def smush(a_number: float) -> float:
     """
     return_value = a_number
     if a_number > 0:
-        return_value = return_value / 2
+        return_value = a_number / 2
     return return_value
 
 


### PR DESCRIPTION
### What

Use different variable in the division calculation of the `smush` function 

### Why

I made a point about using 2 vars in the function (`return_value` and `a_number`) instead of 1 as I felt it made the code clearer despite it having no functional difference. One keen student then said, "would it also not make sense to use the `a_number` in the division calculation since it's the `a_number` that is divided by 2", which I totally agree with. 

### Testing

:+1: 

### Additional Notes

1. It's a small chance, but I'm for it as the student is totally right and I think it's cool that someone noticed something like this
2. I have yet to change csci161 to use the `literal-include`, so I had to chance the code in 2 spots (src and in the topic). 