### PR TITLE
:mortar_board: Outline --- Test 2 date :microscope: 

### DIFF
--- a/site/outline/outline.rst
+++ b/site/outline/outline.rst
@@ -155,7 +155,7 @@ Student Evaluation (Tentative Dates)
       - October 4th
     * - Test 2
       - 20%
-      - End of October-ish
+      - November 15
     * - Final Exam
       - 40%
       - TBD


### PR DESCRIPTION
### What

Set the date for test 2

### Additional Notes

Originally planned for end of oct, but they wanted the test after reading week, so whatever, it's the first wed after reading week. 

The joke is, if you make the test before reading week everyone complains that you should've given them reading week to study for the test. If you make the test after reading week, they complain that you ruined their reading week and that they got rusty from not having class during reading week. 

