### PR TITLE
:mortar_board: Tests --- Only have 2 tests :microscope: 

### DIFF
--- a/site/outline/outline.rst
+++ b/site/outline/outline.rst
@@ -135,13 +135,10 @@ Student Evaluation
       - 5%
       - Sunday August 18, 2024, 11:55pm
     * - Test 1
-      - 20%
-      - Wednesday July 10, 2024
-    * - Test 2
-      - 20%
-      - Wednesday July 31, 2024
+      - 30%
+      - Wednesday July 17, 2024
     * - Final Exam
-      - 40%
+      - 50%
       - TBD
 
 
@@ -213,8 +210,7 @@ Missed Tests
 ------------
 
 There are no make-up tests. If a student is unable to write a test, the weight of their test will be added to the
-following test or final exam, whichever comes first. If both tests are missed, the weight of the tests will be added to
-the final exam.
+final exam.
 
 
 ProctorU

--- a/site/outline/schedule.rst
+++ b/site/outline/schedule.rst
@@ -77,8 +77,6 @@ must be prepared for the pacing of the course.
     * - Test Number
       - Date
     * - Test 1
-      - Wednesday July 10, 2024
-    * - Test 2
-      - Wednesday July 31, 2024
-    * - Test 3 (Final Exam)
+      - Wednesday July 17, 2024
+    * - Test 2 (Final Exam)
       - TBD


### PR DESCRIPTION
### What

Reduce the number of tests to 2 from 3. One midterm and a final. 

### Why

Apparently, because it's remote, they need to pay for a proctor themselves out of their pockets at a price of $40/test, which is lameo. 

### How

Reduce number of tests. Move test 1 one week, and update the grade breakdown. 

### Testing

:-1: 