### PR TITLE
:mortar_board: Schedule --- Move midterm back 1 week :microscope: 

### DIFF
--- a/site/outline/outline.rst
+++ b/site/outline/outline.rst
@@ -136,7 +136,7 @@ Student Evaluation
       - Sunday August 18, 2024, 11:55pm
     * - Test 1
       - 30%
-      - Wednesday July 17, 2024
+      - Wednesday July 24, 2024
     * - Final Exam
       - 50%
       - TBD

--- a/site/outline/schedule.rst
+++ b/site/outline/schedule.rst
@@ -77,6 +77,6 @@ must be prepared for the pacing of the course.
     * - Test Number
       - Date
     * - Test 1
-      - Wednesday July 17, 2024
+      - Wednesday July 24, 2024
     * - Test 2 (Final Exam)
       - TBD


### PR DESCRIPTION
### What

Move the midterm back 1 week, again. 

### Why

More content would have to be covered (lists), and based on the schedule, this seems to be the best place to put the test such that they know enough about lists. 

### Testing

:-1: 

### Additional Notes

When combining the two midterms, some of the content from the 2nd test was cut since not enough content will be covered in the lectures/labs/assignments. That's OK though as I don't want the test to be too long anyways. 