### PR TITLE
:arrow_up: Spring 2025 --- Move dates of A4 and Exam  up

### DIFF
--- a/site/assignments/country-catalogue/country-catalogue.rst
+++ b/site/assignments/country-catalogue/country-catalogue.rst
@@ -3,7 +3,7 @@ Country Catalogue
 *****************
 
 * **Worth**: 5%
-* **DUE**: Monday June 23 at 11:55pm; submitted on MOODLE.
+* **DUE**: Sunday June 22, 2025 at 11:55pm; submitted on MOODLE.
 * **Files**: :download:`asn4.ipynb <asn4.ipynb>`/:download:`asn4.py <asn4.py>` and :download:`country_data.csv <country_data.csv>`
 
 

--- a/site/outline/outline.rst
+++ b/site/outline/outline.rst
@@ -127,13 +127,13 @@ Student Evaluation
       - Monday June 9, 2025, 11:55pm
     * - Assignment 4
       - 5%
-      - Monday June 23, 2025, 11:55pm
+      - Sunday June 22, 2025, 11:55pm
     * - Test 1
       - 30%
       - Wednesday May 28, 2025
     * - Final Exam
       - 50%
-      - Wednesday June 25, 2025
+      - Monday June 23, 2025
 
 
 

--- a/site/outline/schedule.rst
+++ b/site/outline/schedule.rst
@@ -66,7 +66,7 @@ Course Schedule
      * - Assignment 3
        - Monday June 9, 2025, 11:55pm
      * - Assignment 4
-       - Monday June 23, 2025, 11:55pm
+       - Sunday June 22, 2025, 11:55pm
 
 
 
@@ -80,4 +80,4 @@ Course Schedule
      * - Test 1 (Midterm)
        - Wednesday May 28, 2025
      * - Test 2 (Final)
-       - Wednesday June 25, 2025
+       - Monday June 23, 2025


### PR DESCRIPTION
### What

Move dates of assignment 4 and the exam up. 

### Why

161 is to be offered in the Spring and 162 in the Summer. 

Although the week of the 23 is the exam week for Spring, the Summer semester starts that week too. Since 161 is prereq for 162, it would be better to have the exam as early as possible. 
