### PR TITLE
:arrow_up: Python Version --- Set >= 3.12

### DIFF
--- a/.github/workflows/sphinx-build.yml
+++ b/.github/workflows/sphinx-build.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: 3.11
+        python-version: 3.12
     - name: Install Dependencies
       run: |
         pip install -e .
@@ -35,7 +35,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: 3.11
+        python-version: 3.12
     - name: Install Dependencies
       run: |
         pip install -e .

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ pip install -e .
 ## Bash
 
 ```sh
-python3.11 -m venv --clear --prompt cs101 venv
+python3 -m venv --clear --prompt cs101 venv
 . venv/bin/activate
 pip install -e .
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ enabled = true
 
 [tool.black]
 line-length = 120
-target-version = ["py310"]
+target-version = ["py312"]
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ authors = [
 ]
 description = "Introduction to Computer Science"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 license = { text = "GPL-3.0" }
 urls = { "Homepage" = "https://github.com/jameshughes89/cs101" }
 classifiers = [


### PR DESCRIPTION
### What

1. Change python 3.11 -> 3.12. 
2. Update black to use 312 (it was 310). 
3. Change the README to use `python3` instead of `python3.XX`

### Why

RE 1
I just installed Ubuntu 24 and it comes with 3.12, so I figured, _eh, why not_. 

One may ask _why not use 3.14_, but one package may have an issue with 4.14.1 (networkx), so, I will leave that for now. 

RE 2 
(a) it was set to 310 and should have been set to 310. (b) because now it matches 3.12. 

RE 3
Simplifies it for the repo. I know this _could_ create issues, but I think the simplification for the students is better. 

### Testing

was able to get everything installed and tests passed. 

### Additional Notes

I have **not** run `format` on the repo. This is because I have not been running it for a while and there are a lot of things that would be updated. I will do a separate PR for that. 
