### PR TITLE
:lipstick: Labs --- Rename Sections :robot: 

### DIFF
--- a/site/labs/car-rental/car-rental.rst
+++ b/site/labs/car-rental/car-rental.rst
@@ -60,8 +60,8 @@ rental agreement, age, how far they drove, and how long they had the car.
 
 
 
-Kattis Problems
-===============
+Kattis Based Practice
+=====================
 
 * Work on the Kattis problems you have not solved from previous weeks
 * Remember, I encourage you to work with others to solve the problems

--- a/site/labs/car-rental/car-rental.rst
+++ b/site/labs/car-rental/car-rental.rst
@@ -11,15 +11,15 @@ Car Rental
 
 
 
-Pre Lab Exercises
-=================
+Textbook Exercises
+==================
 
 * There are no exercises to complete before this lab
 
 
 
-Before Kattis
-=============
+Core Exercises
+==============
 
 .. image:: /topics/car-rental/carRental.png
 

--- a/site/labs/conditionals/conditionals.rst
+++ b/site/labs/conditionals/conditionals.rst
@@ -48,8 +48,8 @@ Core Exercises
 
 
 
-Kattis Problems
-===============
+Kattis Based Practice
+=====================
 
 * Do not forget the code we used last time to read input on Kattis
 

--- a/site/labs/conditionals/conditionals.rst
+++ b/site/labs/conditionals/conditionals.rst
@@ -11,8 +11,8 @@ Conditionals
 
 
 
-Pre Lab Exercises
-=================
+Textbook Exercises
+==================
 
 #. `Chapter 5 exercise(s) <http://openbookproject.net/thinkcs/python/english3e/conditionals.html#exercises>`_
 
@@ -27,8 +27,8 @@ Pre Lab Exercises
 
 
 
-Before Kattis
-=============
+Core Exercises
+==============
 
 #. Write a function ``did_pass(grade: float) -> bool:`` that returns ``True`` if the grade is 50 or above, and ``False`` otherwise
 

--- a/site/labs/debug/debug.rst
+++ b/site/labs/debug/debug.rst
@@ -11,15 +11,15 @@ Debug
 
 
 
-Pre Lab Exercises
-=================
+Textbook Exercises
+==================
 
 * There are no exercises to complete before this lab
 
 
 
-Before Kattis
-=============
+Core Exercises
+==============
 
 **1**
 

--- a/site/labs/debug/debug.rst
+++ b/site/labs/debug/debug.rst
@@ -326,8 +326,8 @@ This one is very buggy :(
 
 
 
-Kattis Problems
-===============
+Kattis Based Practice
+=====================
 
 I'm willing to bet that in previous weeks you were working on Kattis problems that you couldn't quite debug. You may have been close, or way off, but the problem was you were stuck wondering how best to *fix* your code. Now that you're equipped with the debugger, go back and work on them! Seriously, GO BACK! But make use of this debugger. Whenever you can, USE THE DEBUGGER. Stuck on Kattis? DEBUGGER! Stuck on assignment? DEBUGGER! Stuck in life? DEBUGGER?
 

--- a/site/labs/functions/functions.rst
+++ b/site/labs/functions/functions.rst
@@ -11,8 +11,8 @@ Functions
 
 
 
-Pre Lab Exercises
-=================
+Textbook Exercises
+==================
 
 #. `Chapter 2 exercise(s) <http://openbookproject.net/thinkcs/python/english3e/variables_expressions_statements.html#exercises>`_
 
@@ -24,8 +24,8 @@ Pre Lab Exercises
     * 8
 
 
-Before Kattis
-=============
+Core Exercises
+==============
 
 * :doc:`If you forget how to do the function related stuff, go back to the class notes </topics/functions/functions>`
 

--- a/site/labs/functions/functions.rst
+++ b/site/labs/functions/functions.rst
@@ -103,8 +103,8 @@ Core Exercises
 
 
 
-Kattis Problems
-===============
+Kattis Based Practice
+=====================
 
 * Do not forget the code we used last time to read input on Kattis
 

--- a/site/labs/hello-world/hello-world.rst
+++ b/site/labs/hello-world/hello-world.rst
@@ -83,8 +83,8 @@ Refreshing What We Learned
 
 
 
-Kattis Problems
-===============
+Kattis Based Practice
+=====================
 
 .. admonition:: Note
     :class: note

--- a/site/labs/hello-world/hello-world.rst
+++ b/site/labs/hello-world/hello-world.rst
@@ -11,8 +11,8 @@ Hello World
 
 
 
-Pre Lab Exercises
-=================
+Textbook Exercises
+==================
 
 #. `Chapter 1 exercise(s) <http://openbookproject.net/thinkcs/python/english3e/way_of_the_program.html#exercises>`_
 
@@ -28,8 +28,11 @@ Pre Lab Exercises
 
 
 
+Core Exercises
+==============
+
 Hello World
-===========
+-----------
 
 #. Log onto your computer
 #. Log into Colab
@@ -45,7 +48,7 @@ Hello World
 
 
 Refreshing What We Learned
-==========================
+--------------------------
 
 #. Enter and run the following code
 
@@ -80,8 +83,8 @@ Refreshing What We Learned
 
 
 
-Kattis
-======
+Kattis Problems
+===============
 
 .. admonition:: Note
     :class: note

--- a/site/labs/lists/1d-lists.rst
+++ b/site/labs/lists/1d-lists.rst
@@ -63,8 +63,8 @@ Core Exercises
 
 
 
-Kattis Problems
-===============
+Kattis Based Practice
+=====================
 
 * You should be using a scrap piece of paper to work out the ideas for the following problems
 

--- a/site/labs/lists/1d-lists.rst
+++ b/site/labs/lists/1d-lists.rst
@@ -11,8 +11,8 @@ Lists
 
 
 
-Pre Lab Exercises
-=================
+Textbook Exercises
+==================
 
 * For all exercises
 
@@ -32,8 +32,8 @@ Pre Lab Exercises
 
 
 
-Before Kattis
-=============
+Core Exercises
+==============
 
 #. Write a function ``linear_search(needle, haystack) -> bool:``
 

--- a/site/labs/lists/2d-lists.rst
+++ b/site/labs/lists/2d-lists.rst
@@ -11,8 +11,8 @@
 
 
 
-Pre Lab Exercises
-=================
+Textbook Exercises
+==================
 
 * For all exercises
 
@@ -32,8 +32,8 @@ Pre Lab Exercises
 
 
 
-Before Kattis
-=============
+Core Exercises
+==============
 
 .. note::
 

--- a/site/labs/lists/2d-lists.rst
+++ b/site/labs/lists/2d-lists.rst
@@ -140,8 +140,8 @@ Given the following code:
                     ['j', 'k', 'l', 'z']]
 
 
-Kattis Problems
-===============
+Kattis Based Practice
+=====================
 
 * You should be using a scrap piece of paper to work out the ideas for the following problems
 

--- a/site/labs/lists/references.rst
+++ b/site/labs/lists/references.rst
@@ -11,8 +11,8 @@ References & More Lists
 
 
 
-Pre Lab Exercises
-=================
+Textbook Exercises
+==================
 
 * For all exercises
 
@@ -31,8 +31,8 @@ Pre Lab Exercises
 
 
 
-Before Kattis
-=============
+Core Exercises
+==============
 
 #. Run the following code and figure out what it does and how it does it
 

--- a/site/labs/lists/references.rst
+++ b/site/labs/lists/references.rst
@@ -98,8 +98,8 @@ Core Exercises
  
 
 
-Kattis Problems
-===============
+Kattis Based Practice
+=====================
 
 * You should be using a scrap piece of paper to work out the ideas for the following problems
 

--- a/site/labs/loops-linear-search/loops-linear-search.rst
+++ b/site/labs/loops-linear-search/loops-linear-search.rst
@@ -77,8 +77,8 @@ Core Exercises
 
 
 
-Kattis Problems
-===============
+Kattis Based Practice
+=====================
 
 * You should be using a scrap piece of paper to work out the ideas for the following problems
 

--- a/site/labs/loops-linear-search/loops-linear-search.rst
+++ b/site/labs/loops-linear-search/loops-linear-search.rst
@@ -11,8 +11,8 @@ Loops & Linear Search
 
 
 
-Pre Lab Exercises
-=================
+Textbook Exercises
+==================
 
 #. `Chapter 7 exercise(s) <http://openbookproject.net/thinkcs/python/english3e/iteration.html#exercises>`_
 
@@ -37,8 +37,8 @@ Pre Lab Exercises
 
 
 
-Before Kattis
-=============
+Core Exercises
+==============
 
 #. Write a function ``count_to_n_while(n: int):`` to print out each number from :math:`0` -- :math:`(n - 1)`
 

--- a/site/labs/objects/data-structures.rst
+++ b/site/labs/objects/data-structures.rst
@@ -63,8 +63,8 @@ Core Exercises
 
 
 
-Kattis Problems
-===============
+Kattis Based Practice
+=====================
 
 Go back and work on Kattis problems from previous labs that you have yet to solve. I'm betting there are several of the
 earlier ones you can revisit and solve. Remember, the Kattis problems are great for practice, and practice is the only

--- a/site/labs/objects/data-structures.rst
+++ b/site/labs/objects/data-structures.rst
@@ -11,8 +11,8 @@ Data Structures
 
 
 
-Pre Lab Exercises
-=================
+Textbook Exercises
+==================
 
 #. Have all classes from the previous lab complete
 #. `Chapter 15 exercise(s) <http://openbookproject.net/thinkcs/python/english3e/classes_and_objects_I.html#exercises>`_
@@ -27,8 +27,8 @@ Pre Lab Exercises
 
 
 
-Before Kattis
-=============
+Core Exercises
+==============
 
 #. Have a complete ``Person`` class from the previous lab
 #. Write a ``Contacts`` class that will manage a collection of ``Person`` objects

--- a/site/labs/objects/objects.rst
+++ b/site/labs/objects/objects.rst
@@ -11,8 +11,8 @@ Objects
 
 
 
-Pre Lab Exercises
-=================
+Textbook Exercises
+==================
 
 #. Have a working implementation of the ``Circle`` class from :doc:`lecture </topics/objects/introduction>`
 
@@ -33,8 +33,8 @@ Pre Lab Exercises
     
     
 
-Before Kattis
-=============
+Core Exercises
+==============
 
 #. Create a ``Square`` class
 

--- a/site/labs/objects/objects.rst
+++ b/site/labs/objects/objects.rst
@@ -65,8 +65,8 @@ Core Exercises
 
 
 
-Kattis Problems
-===============
+Kattis Based Practice
+=====================
 
 * You should be using a scrap piece of paper to work out the ideas for the following problems
 

--- a/site/labs/testing/testing.rst
+++ b/site/labs/testing/testing.rst
@@ -64,8 +64,8 @@ Core Exercises
 
 
 
-Kattis Problems
-===============
+Kattis Based Practice
+=====================
 
 * Do not forget the code we used last time to read input on Kattis
 

--- a/site/labs/testing/testing.rst
+++ b/site/labs/testing/testing.rst
@@ -11,8 +11,8 @@ Testing
 
 
 
-Pre Lab Exercises
-=================
+Textbook Exercises
+==================
 
 #. `Chapter 2 exercise(s) <http://openbookproject.net/thinkcs/python/english3e/variables_expressions_statements.html#exercises>`_
 
@@ -26,8 +26,8 @@ Pre Lab Exercises
 
 
 
-Before Kattis
-=============
+Core Exercises
+==============
 
 * :doc:`If you forget how to do the testing and type hint related stuff, go back to the class notes </topics/testing/testing>`
 

--- a/site/labs/testing/unittest-objects.rst
+++ b/site/labs/testing/unittest-objects.rst
@@ -11,15 +11,15 @@ Unit Testing Objects
 
 
 
-Pre Lab Exercises
-=================
+Textbook Exercises
+==================
 
 * Have the previous lab complete
 
 
 
-Before Kattis
-=============
+Core Exercises
+==============
 
 #. Create a ``Person`` class
 

--- a/site/labs/testing/unittest-objects.rst
+++ b/site/labs/testing/unittest-objects.rst
@@ -47,8 +47,8 @@ Core Exercises
 
 
 
-Kattis Problems
-===============
+Kattis Based Practice
+=====================
 
 * You should be using a scrap piece of paper to work out the ideas for the following problems
 

--- a/site/outline/outline.rst
+++ b/site/outline/outline.rst
@@ -232,18 +232,18 @@ Lab Procedure
 
 Each lab consists of three parts:
 
-    #. Pre-lab exercises
-    #. Before Kattis exercises
+    #. Textbook Exercises
+    #. Core Exercises
     #. Kattis Problems
 
 
-The "pre-lab" exercises are from the free course textbook and are selected based on their relevance to the course
+The "Textbook Exercises" are from the free course textbook and are selected based on their relevance to the course
 material.
 
-The "before Kattis exercises" are the core part of each lab. These questions are designed to directly complement the
+The "Core Exercises" are the core part of each lab. These questions are designed to directly complement the
 course material covered in the topics and emphasize specific technical skills.
 
-The "Kattis problems" are problems selected from Kattis, a website with programming competition style problems where
+The "Kattis Problems" are problems selected from Kattis, a website with programming competition style problems where
 people can submit their solutions for automated evaluation. A select set of Kattis problems related to course material
 are included at the end of each lab for students to work on. It is not necessary to complete all these problems for each
 lab as they can be quite challenging.

--- a/site/outline/outline.rst
+++ b/site/outline/outline.rst
@@ -240,8 +240,8 @@ Each lab consists of three parts:
 The "Textbook Exercises" are from the free course textbook and are selected based on their relevance to the course
 material.
 
-The "Core Exercises" are the core part of each lab. These questions are designed to directly complement the
-course material covered in the topics and emphasize specific technical skills.
+The "Core Exercises" are the core part of each lab. These questions are designed to directly complement the course
+material covered in the topics and emphasize specific technical skills.
 
 The "Kattis Problems" are problems selected from Kattis, a website with programming competition style problems where
 people can submit their solutions for automated evaluation. A select set of Kattis problems related to course material

--- a/site/outline/outline.rst
+++ b/site/outline/outline.rst
@@ -234,7 +234,7 @@ Each lab consists of three parts:
 
     #. Textbook Exercises
     #. Core Exercises
-    #. Kattis Problems
+    #. Kattis Based Practice
 
 
 The "Textbook Exercises" are from the free course textbook and are selected based on their relevance to the course
@@ -243,10 +243,10 @@ material.
 The "Core Exercises" are the core part of each lab. These questions are designed to directly complement the course
 material covered in the topics and emphasize specific technical skills.
 
-The "Kattis Problems" are problems selected from Kattis, a website with programming competition style problems where
-people can submit their solutions for automated evaluation. A select set of Kattis problems related to course material
-are included at the end of each lab for students to work on. It is not necessary to complete all these problems for each
-lab as they can be quite challenging.
+The "Kattis Based Practice" section uses problems selected from Kattis, a website with programming competition style
+problems where people can submit their solutions for automated evaluation. A select set of Kattis problems related to
+course material are included at the end of each lab for students to work on. It is not necessary to complete all these
+problems for each lab as they can be quite challenging.
 
 Students are not to submit any lab work for evaluation, but students are recommended to attend office hours to discuss
 any questions they have regarding the material.


### PR DESCRIPTION
### Related Issues or PRs

Closes #485 

### What

Rename 
"pre lab" to "textbook exercises"
"before kattis" to "core exercises"
"kattis problems" to "kattis based practice" 

Also updated outline accordingly


### Why

The new section names better reflect the spirit of what they are. Note that I expect the lab format to change for Fall 2026 so don't get too married to anything here. 


### How

Copilot
